### PR TITLE
La PostgresTestContainerBase wire opp  DBVerify selv

### DIFF
--- a/src/test/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieControllerTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieControllerTest.kt
@@ -11,7 +11,6 @@ import no.nav.faktureringskomponenten.controller.dto.FullmektigDto
 import no.nav.faktureringskomponenten.domain.models.FakturaserieStatus
 import no.nav.faktureringskomponenten.domain.repositories.FakturaserieRepository
 import no.nav.faktureringskomponenten.security.SubjectHandler.Companion.azureActiveDirectory
-import no.nav.faktureringskomponenten.testutils.DBVerify
 import no.nav.faktureringskomponenten.testutils.PostgresTestContainerBase
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
@@ -45,8 +44,7 @@ class FakturaserieControllerTest(
     @Autowired private val webClient: WebTestClient,
     @Autowired private val server: MockOAuth2Server,
     @Autowired private val fakturaserieRepository: FakturaserieRepository,
-    @Autowired private val dbVerify: DBVerify
-) : PostgresTestContainerBase(dbVerify) {
+) : PostgresTestContainerBase() {
 
     @Test
     @Disabled("Skal ikke støtte endring av fakturaserie i denne versjonen")

--- a/src/test/kotlin/no/nav/faktureringskomponenten/domain/repositories/FakturaserieRepositoryIT.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/domain/repositories/FakturaserieRepositoryIT.kt
@@ -4,7 +4,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import no.nav.faktureringskomponenten.domain.models.*
-import no.nav.faktureringskomponenten.testutils.DBVerify
 import no.nav.faktureringskomponenten.testutils.PostgresTestContainerBase
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,8 +18,7 @@ import java.time.LocalDate
 class FakturaserieRepositoryIT(
     @Autowired private val fakturaRepository: FakturaRepository,
     @Autowired private val fakturaserieRepository: FakturaserieRepository,
-    @Autowired private val dbVerify: DBVerify
-) : PostgresTestContainerBase(dbVerify) {
+) : PostgresTestContainerBase() {
 
     @Test
     fun test_findAllByDatoBestiltIsLessThanEqualAndStatusIs() {

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaServiceIT.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaServiceIT.kt
@@ -13,7 +13,6 @@ import no.nav.faktureringskomponenten.domain.repositories.FakturaserieRepository
 import no.nav.faktureringskomponenten.service.cronjob.FakturaBestillCronjob
 import no.nav.faktureringskomponenten.service.integration.kafka.FakturaBestiltProducer
 import no.nav.faktureringskomponenten.service.integration.kafka.dto.FakturaBestiltDto
-import no.nav.faktureringskomponenten.testutils.DBVerify
 import no.nav.faktureringskomponenten.testutils.PostgresTestContainerBase
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.AfterEach
@@ -39,8 +38,7 @@ class FakturaServiceIT(
     @Autowired private val fakturaRepository: FakturaRepository,
     @Autowired private val fakturaserieRepository: FakturaserieRepository,
     @Autowired private val fakturaBestillCronjob: FakturaBestillCronjob,
-    @Autowired private val dbVerify: DBVerify
-) : PostgresTestContainerBase(dbVerify) {
+) : PostgresTestContainerBase() {
 
     private var fakturaId: Long? = null
 

--- a/src/test/kotlin/no/nav/faktureringskomponenten/testutils/PostgresTestContainerBase.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/testutils/PostgresTestContainerBase.kt
@@ -1,15 +1,19 @@
 package no.nav.faktureringskomponenten.testutils
 
 import org.junit.jupiter.api.AfterEach
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
 
 @Import(value = [DBVerify::class])
-open class PostgresTestContainerBase(
-    private val dbVerify: DBVerify
-) {
+open class PostgresTestContainerBase {
+
+    @Suppress("SpringJavaAutowiredMembersInspection")
+    @Autowired
+    private lateinit var dbVerify: DBVerify
+
     companion object {
         var dbContainer = PostgreSQLContainer("postgres:12.11")
 


### PR DESCRIPTION
For at test klassene skal slippe å ha unødvendig kode