### PR TITLE
NOJIRA Lagt til dokumentasjon på 401 Ubuntu feil i tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dette vil se slik ut:
 ```hosts
     127.0.0.1 localhost
     127.0.0.1 view-localhost
-    127.0.1.1 <din-maskin-navn>
+    127.0.1.1 <din-maskin>
 ```
 
 


### PR DESCRIPTION
Oppdatert dokumentasjon på hvordan vi på Ubuntu løser feilen som har skapet problemer.

Det viste seg at issuer URLen ble feil på Ubuntu maskiner som har en hosts konfigurasjon som gjør om 127.0.0.1 til view-localhost istedet for localhost. Hvorfor eller hvordan dette _egentlig_ fungerer er ikke godt å si, men nå er i allefall problemet løsbar! 