### PR TITLE
5906 Overlappende perioder havner i samme faktura

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/dto/FakturaserieRequestDto.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/dto/FakturaserieRequestDto.kt
@@ -49,7 +49,7 @@ data class FakturaserieRequestDto(
         description = "Betalingsintervall",
         example = "KVARTAL",
     )
-    val intervall: FakturaserieIntervall = FakturaserieIntervall.MANEDLIG,
+    val intervall: FakturaserieIntervall = FakturaserieIntervall.KVARTAL,
 
     @field:Schema(description = "Liste av betalingsperioder, kan ikke være tom")
     @field:NotEmpty(message = "Du må oppgi minst én periode")

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/mappers/FakturalinjeMapperTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/mappers/FakturalinjeMapperTest.kt
@@ -1,5 +1,6 @@
 package no.nav.faktureringskomponenten.service.mappers
 
+import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import no.nav.faktureringskomponenten.controller.dto.FakturaseriePeriodeDto
@@ -39,5 +40,31 @@ class FakturalinjeMapperTest {
                 periodeTil.shouldBe(til)
                 beskrivelse.shouldBe("Inntekt: 80000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %")
             }
+    }
+
+    @Test
+    fun `to perioder med samme fom og tom datoer`() {
+        val fra = LocalDate.of(2023, 1, 1)
+        val til = LocalDate.of(2023, 1, 31)
+        val perioder = listOf(
+            FakturaseriePeriode(
+                enhetsprisPerManed = BigDecimal(22830),
+                startDato = fra,
+                sluttDato = til,
+                beskrivelse = "Inntekt: 80000, Dekning: Pensjonsdel, Sats: 21.5 %"
+            ),
+            FakturaseriePeriode(
+                enhetsprisPerManed = BigDecimal(25470),
+                startDato = fra,
+                sluttDato = til,
+                beskrivelse = "Inntekt: 80000, Dekning: Helse- og pensjonsdel, Sats: 28.3 %"
+            )
+        )
+
+        val fakturaLinjer = FakturalinjeMapper().tilFakturaLinjer(perioder, fra, til)
+
+        fakturaLinjer.shouldHaveSize(2)
+        fakturaLinjer.map { it.periodeFra }.shouldContainOnly(fra)
+        fakturaLinjer.map { it.periodeTil }.shouldContainOnly(til)
     }
 }

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/mappers/FakturalinjeMapperTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/mappers/FakturalinjeMapperTest.kt
@@ -3,9 +3,7 @@ package no.nav.faktureringskomponenten.service.mappers
 import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import no.nav.faktureringskomponenten.controller.dto.FakturaseriePeriodeDto
 import no.nav.faktureringskomponenten.domain.models.FakturaseriePeriode
-import no.nav.faktureringskomponenten.service.mappers.FakturalinjeMapper
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -44,27 +42,30 @@ class FakturalinjeMapperTest {
 
     @Test
     fun `to perioder med samme fom og tom datoer`() {
-        val fra = LocalDate.of(2023, 1, 1)
-        val til = LocalDate.of(2023, 1, 31)
+        val fakturaFraDato = LocalDate.of(2023, 1, 1)
+        val fakturaTilDato = LocalDate.of(2023, 3, 31)
+        val periodeFraDato = LocalDate.of(2023, 2, 1)
+        val periodeTilDato = LocalDate.of(2023, 3, 31)
+
         val perioder = listOf(
             FakturaseriePeriode(
                 enhetsprisPerManed = BigDecimal(22830),
-                startDato = fra,
-                sluttDato = til,
+                startDato = periodeFraDato,
+                sluttDato = periodeTilDato,
                 beskrivelse = "Inntekt: 80000, Dekning: Pensjonsdel, Sats: 21.5 %"
             ),
             FakturaseriePeriode(
                 enhetsprisPerManed = BigDecimal(25470),
-                startDato = fra,
-                sluttDato = til,
+                startDato = periodeFraDato,
+                sluttDato = periodeTilDato,
                 beskrivelse = "Inntekt: 80000, Dekning: Helse- og pensjonsdel, Sats: 28.3 %"
             )
         )
 
-        val fakturaLinjer = FakturalinjeMapper().tilFakturaLinjer(perioder, fra, til)
+        val fakturaLinjer = FakturalinjeMapper().tilFakturaLinjer(perioder, fakturaFraDato, fakturaTilDato)
 
         fakturaLinjer.shouldHaveSize(2)
-        fakturaLinjer.map { it.periodeFra }.shouldContainOnly(fra)
-        fakturaLinjer.map { it.periodeTil }.shouldContainOnly(til)
+        fakturaLinjer.map { it.periodeFra }.shouldContainOnly(periodeFraDato)
+        fakturaLinjer.map { it.periodeTil }.shouldContainOnly(periodeTilDato)
     }
 }


### PR DESCRIPTION
Ref: https://nav-it.slack.com/archives/C01CFP7SL4Q/p1683879427862769?thread_ts=1683878879.815269&cid=C01CFP7SL4Q

Endret samtidig kjapt default betalingsintervall til KVARTAL: Muntlig diskusjon. Det er kvartalsmessig som brukes i avgiftssystemet idag, så det gir mer mening å ha dette som default istedenfor månedlig. Bruker kan heller ikke velge dette i søknaden så muligheten for å velge dette skal fjernes fra vedtak-steget. Det vil i den oppgaven bli viktig at vi har rett default.

https://jira.adeo.no/browse/MELOSYS-5906