### PR TITLE
MELOSYS 6078  fjern filter db

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieController.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieController.kt
@@ -75,8 +75,7 @@ class FakturaserieController @Autowired constructor(
     @GetMapping
     fun hentFakturaserier(
         @RequestParam("referanse") referanse: String,
-        @RequestParam(value = "fakturaStatus", required = false) fakturaStatus: String? = null
 ): List<FakturaserieResponseDto> {
-        return faktureringService.hentFakturaserier(referanse, fakturaStatus).map { it.tilFakturaserieResponseDto }
+        return faktureringService.hentFakturaserier(referanse).map { it.tilFakturaserieResponseDto }
     }
 }

--- a/src/main/kotlin/no/nav/faktureringskomponenten/domain/repositories/FakturaserieRepository.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/domain/repositories/FakturaserieRepository.kt
@@ -1,6 +1,5 @@
 package no.nav.faktureringskomponenten.domain.repositories
 
-import no.nav.faktureringskomponenten.domain.models.FakturaStatus
 import no.nav.faktureringskomponenten.domain.models.Fakturaserie
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -16,8 +15,7 @@ interface FakturaserieRepository : JpaRepository<Fakturaserie, String> {
     * av relasjonen. Kan se på dette som en som sjekker høyre og venstre, er det
     * noen relasjoner av meg til venstre(fakturaserie_forward) blir de funnnet av
     * denne CTE, hvis det er noen til høyre(fakturaserie_reverse) blir de funnnet
-    * av denne. Så den endelige SELECT henter svar fra begge CTE og joiner faktura
-    * og finner hvilke fakturaserie som har faktura med gitt status.
+    * av denne. Så den endelige SELECT henter svar fra begge CTE.
     * */
     @Query(value = """
     WITH RECURSIVE 

--- a/src/main/kotlin/no/nav/faktureringskomponenten/domain/repositories/FakturaserieRepository.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/domain/repositories/FakturaserieRepository.kt
@@ -39,16 +39,11 @@ interface FakturaserieRepository : JpaRepository<Fakturaserie, String> {
         JOIN fakturaserie_reverse fr ON fs.id = fr.erstattet_med
     )
     SELECT distinct fs.* FROM fakturaserie_forward fs
-    JOIN Faktura f ON f.fakturaserie_id = fs.id
-    WHERE (:fakturaStatus IS NULL OR CAST(f.status AS varchar) = :fakturaStatus)
     UNION ALL
     SELECT distinct fs.* FROM fakturaserie_reverse fs
-    JOIN Faktura f ON f.fakturaserie_id = fs.id
-    WHERE (:fakturaStatus IS NULL OR CAST(f.status AS varchar) = :fakturaStatus)
     """, nativeQuery = true)
     fun findAllByReferanse(
         @Param("referanse") referanse: String,
-        @Param("fakturaStatus") fakturaStatus: String?
     ): List<Fakturaserie>
 
 

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieService.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieService.kt
@@ -21,8 +21,8 @@ class FakturaserieService(
             message = "Fant ikke fakturaserie på: $referanse"
         )
 
-    fun hentFakturaserier(referanse: String, fakturaStatus: String?): List<Fakturaserie> {
-        return fakturaserieRepository.findAllByReferanse(referanse, fakturaStatus)
+    fun hentFakturaserier(referanse: String): List<Fakturaserie> {
+        return fakturaserieRepository.findAllByReferanse(referanse)
     }
 
     @Transactional

--- a/src/test/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieControllerIT.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieControllerIT.kt
@@ -100,7 +100,7 @@ class FakturaserieControllerIT(
     }
 
     @Test
-    fun `hent fakturaserier basert på referanseId med fakturastatus filter`() {
+    fun `hent fakturaserier basert på referanseId`() {
         val startDato = LocalDate.parse("2023-01-01")
         val sluttDato = LocalDate.parse("2024-03-31")
         val fakturaSerieDto = lagFakturaserieDto(
@@ -122,16 +122,6 @@ class FakturaserieControllerIT(
         responseAlleFakturaserier?.size.shouldBe(4)
         responseAlleFakturaserier?.filter { it.status == FakturaserieStatus.ERSTATTET }?.size.shouldBe(3)
         responseAlleFakturaserier?.filter { it.status == FakturaserieStatus.OPPRETTET }?.size.shouldBe(1)
-
-        val responseAlleFakturaserierKunKansellert = hentFakturaserierRequest(fakturaserieResponse4Referanse, "&fakturaStatus=${FakturaStatus.KANSELLERT}")
-            .expectStatus().isOk
-            .expectBodyList(FakturaserieResponseDto::class.java).returnResult().responseBody
-
-        responseAlleFakturaserierKunKansellert?.size.shouldBe(3)
-        responseAlleFakturaserierKunKansellert?.stream()?.forEach {
-            it.status.shouldBe(FakturaserieStatus.ERSTATTET)
-            it.faktura.forEach { it.status.shouldBe(FakturaStatus.KANSELLERT) }
-        }
     }
 
 
@@ -267,9 +257,9 @@ class FakturaserieControllerIT(
             }
             .exchange()
 
-    private fun hentFakturaserierRequest(referanse: String, fakturaStatus: String? = null): WebTestClient.ResponseSpec =
+    private fun hentFakturaserierRequest(referanse: String): WebTestClient.ResponseSpec =
         webClient.get()
-            .uri("/fakturaserier?referanse=$referanse${fakturaStatus ?: ""}")
+            .uri("/fakturaserier?referanse=$referanse")
             .accept(MediaType.APPLICATION_JSON)
             .headers {
                 it.set(HttpHeaders.CONTENT_TYPE, "application/json")


### PR DESCRIPTION
Vi har en ganske stor rekursiv sql query, og jeg synes det er veldig
komplisert alerede. Tror det er bedre å filtrere på diverse
fakturastatuser i frontend istedenfor, når det kan komme flere ting å
filtrere på, vil denne bare bli større og mer uleselig. Fjerner derfor
denne.

https://jira.adeo.no/browse/MELOSYS-6078