### PR TITLE
gradle-build-action og wrapper validering

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,15 +21,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Setup gradle dependency cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/.*gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run tests
         run: ./gradlew test
       - name: Build


### PR DESCRIPTION
1) https://github.com/gradle/gradle-build-action
>The gradle-build-action collects information about any Gradle executions that occur in a workflow, and reports these via a Job Summary, visible in the GitHub Actions UI.

gradle-build-action tar seg av caching også

2) Valider Gradle wrapper (se ev. https://github.com/gradle/wrapper-validation-action)