### PR TITLE
6060 flere loepende avregninger

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/avregning/AvregningsfakturaGenerator.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/avregning/AvregningsfakturaGenerator.kt
@@ -20,6 +20,7 @@ class AvregningsfakturaGenerator {
                 referertFakturaVedAvregning = it.bestilteFaktura,
                 periodeFra = it.periodeFra,
                 periodeTil = it.periodeTil,
+                // Rekkefølgen her kan ikke endres uten å endre parseLinjeForTidligereBeløp i AvregningBehandler
                 beskrivelse = "nytt beløp: ${decimalFormat.format(it.nyttBeløp)} - tidligere beløp: ${decimalFormat.format(it.tidligereBeløp)}",
                 antall = BigDecimal(1),
                 enhetsprisPerManed = it.nyttBeløp - it.tidligereBeløp,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6060

Flere løpende avregninger på rad må kunne fungere. Tanken er å bruke linjene fra tidligere avregningsfaktura.
Å parse beskrivelsen er jo litt hacky, så det spørs om man bør lagre beregnet avregningsbeløp i stedet.

Å beregne alt på nytt virker ikke aktuelt: da kan kodeendringer gjør at man ikke finner riktig beløp som ble angitt på
en avregningslinje.

Koden er også kanskje litt vanskelig å skjønne, så jeg tenker det er bra å få flere tilbakemeldinger
