### PR TITLE
6280 deploy checkout hentet ikke historikk

### DIFF
--- a/.github/workflows/deploy-q2.yaml
+++ b/.github/workflows/deploy-q2.yaml
@@ -70,6 +70,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: pre-deploy
         uses: navikt/digihot-deploy/actions/pre-deploy@v2
         env:


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6280

fetch-depth=0 gjør at vi henter hele historikken, ellers hentes bare siste commit. Uten historikk kan vi ikke gjøre sammenligning med siste release og dermed ikke lage changelog. I api f.eks er dette med, så må ha blitt glemt i kopieringa