### PR TITLE
6130: Tester for EksternFakturaStatusService

### DIFF
--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/EksternFakturaStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/EksternFakturaStatusServiceTest.kt
@@ -1,22 +1,30 @@
 package no.nav.faktureringskomponenten.service
 
-import io.mockk.every
-import io.mockk.mockk
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import no.nav.faktureringskomponenten.domain.models.EksternFakturaStatus
+import no.nav.faktureringskomponenten.domain.models.Faktura
 import no.nav.faktureringskomponenten.domain.models.FakturaStatus
+import no.nav.faktureringskomponenten.domain.models.Fakturaserie
 import no.nav.faktureringskomponenten.domain.repositories.FakturaRepository
 import no.nav.faktureringskomponenten.exceptions.RessursIkkeFunnetException
 import no.nav.faktureringskomponenten.service.integration.kafka.ManglendeFakturabetalingProducer
+import no.nav.faktureringskomponenten.service.integration.kafka.dto.Betalingstatus
 import no.nav.faktureringskomponenten.service.integration.kafka.dto.EksternFakturaStatusDto
+import no.nav.faktureringskomponenten.service.integration.kafka.dto.ManglendeFakturabetalingDto
 import no.nav.faktureringskomponenten.service.mappers.EksternFakturaStatusMapper
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.LocalDate
 
 class EksternFakturaStatusServiceTest {
 
     private val fakturaRepository = mockk<FakturaRepository>()
     private val eksternFakturaStatusMapper = mockk<EksternFakturaStatusMapper>()
-    private val manglendeFakturabetalingProducer = mockk<ManglendeFakturabetalingProducer>()
-    private val service = EksternFakturaStatusService(fakturaRepository, eksternFakturaStatusMapper, manglendeFakturabetalingProducer)
+    private val manglendeFakturabetalingProducer = mockk<ManglendeFakturabetalingProducer>(relaxed = true)
+    private val service =
+        EksternFakturaStatusService(fakturaRepository, eksternFakturaStatusMapper, manglendeFakturabetalingProducer)
 
     @Test
     fun `lagreEksternFakturaStatusMelding kaster ExternalErrorException når status er feil`() {
@@ -32,8 +40,137 @@ class EksternFakturaStatusServiceTest {
             feilmelding = "Feilmelding"
         )
 
-        org.junit.jupiter.api.assertThrows<RessursIkkeFunnetException> {
+
+        shouldThrow<RessursIkkeFunnetException> {
             service.lagreEksternFakturaStatusMelding(eksternFakturaStatusDto)
+        }.run {
+            message shouldBe "Finner ikke faktura med faktura referanse nr 123"
+            field shouldBe "faktura.referanseNr"
+        }
+    }
+
+    @Test
+    fun `lagreEksternfakturaStatusMelding sender ikke kafkamelding når melding fra OEBS er duplikat`() {
+        val eksternFakturaStatusDto = EksternFakturaStatusDto(
+            fakturaReferanseNr = "123",
+            fakturaNummer = "82",
+            dato = LocalDate.of(2023, 2, 1),
+            status = FakturaStatus.MANGLENDE_INNBETALING,
+            fakturaBelop = BigDecimal(1000),
+            ubetaltBelop = BigDecimal(1000),
+            feilmelding = null
+        )
+        val eksternFakturaStatus = EksternFakturaStatus(
+            id = 1L,
+            status = eksternFakturaStatusDto.status,
+            feilMelding = eksternFakturaStatusDto.feilmelding,
+        )
+        val faktura = Faktura(
+            id = 1L,
+            status = FakturaStatus.MANGLENDE_INNBETALING,
+            eksternFakturaStatus = mutableListOf(eksternFakturaStatus)
+        )
+
+        every { fakturaRepository.findByReferanseNr("123") } returns faktura
+        every {
+            eksternFakturaStatusMapper.tilEksternFakturaStatus(
+                eksternFakturaStatusDto,
+                any()
+            )
+        } returns eksternFakturaStatus
+        every { fakturaRepository.save(any()) } returns faktura
+
+
+        service.lagreEksternFakturaStatusMelding(eksternFakturaStatusDto)
+
+
+        verify { manglendeFakturabetalingProducer wasNot Called }
+        verify { fakturaRepository.save(any()) }
+    }
+
+    @Test
+    fun `lagreEksternFakturaStatusMelding sender kafkamelding ved manglende betaling med status IKKE_BETALT`() {
+        val eksternFakturaStatusDto = EksternFakturaStatusDto(
+            fakturaReferanseNr = "123",
+            fakturaNummer = "82",
+            dato = LocalDate.of(2023, 2, 1),
+            status = FakturaStatus.MANGLENDE_INNBETALING,
+            fakturaBelop = BigDecimal(1000),
+            ubetaltBelop = BigDecimal(1000),
+            feilmelding = null
+        )
+        val faktura = Faktura(id = 1L, referanseNr = "123", fakturaserie = Fakturaserie(referanse = "321"))
+        every { fakturaRepository.findByReferanseNr("123") } returns faktura
+        every {
+            eksternFakturaStatusMapper.tilEksternFakturaStatus(
+                eksternFakturaStatusDto,
+                any()
+            )
+        } returns EksternFakturaStatus(
+            id = null,
+            dato = eksternFakturaStatusDto.dato,
+            status = eksternFakturaStatusDto.status,
+            fakturaBelop = eksternFakturaStatusDto.fakturaBelop,
+            ubetaltBelop = eksternFakturaStatusDto.ubetaltBelop,
+            feilMelding = eksternFakturaStatusDto.feilmelding,
+            faktura = faktura
+        )
+        every { fakturaRepository.save(any()) } returns faktura
+        val manglendeFakturabetalingSlot = slot<ManglendeFakturabetalingDto>()
+
+
+        service.lagreEksternFakturaStatusMelding(eksternFakturaStatusDto)
+
+
+        verify { manglendeFakturabetalingProducer.produserBestillingsmelding(capture(manglendeFakturabetalingSlot)) }
+        manglendeFakturabetalingSlot.captured.run {
+            fakturaserieReferanse shouldBe "321"
+            betalingstatus shouldBe Betalingstatus.IKKE_BETALT
+            fakturanummer shouldBe "82"
+            datoMottatt shouldBe LocalDate.of(2023, 2, 1)
+        }
+    }
+
+    @Test
+    fun `lagreEksternFakturaStatusMelding sender kafkamelding ved manglende betaling med status DELVIS_BETALT`() {
+        val eksternFakturaStatusDto = EksternFakturaStatusDto(
+            fakturaReferanseNr = "123",
+            fakturaNummer = "82",
+            dato = LocalDate.of(2023, 2, 1),
+            status = FakturaStatus.MANGLENDE_INNBETALING,
+            fakturaBelop = BigDecimal(2000),
+            ubetaltBelop = BigDecimal(1000),
+            feilmelding = null
+        )
+        val faktura = Faktura(id = 1L, referanseNr = "123", fakturaserie = Fakturaserie(referanse = "321"))
+        every { fakturaRepository.findByReferanseNr("123") } returns faktura
+        every {
+            eksternFakturaStatusMapper.tilEksternFakturaStatus(
+                eksternFakturaStatusDto,
+                any()
+            )
+        } returns EksternFakturaStatus(
+            id = null,
+            dato = eksternFakturaStatusDto.dato,
+            status = eksternFakturaStatusDto.status,
+            fakturaBelop = eksternFakturaStatusDto.fakturaBelop,
+            ubetaltBelop = eksternFakturaStatusDto.ubetaltBelop,
+            feilMelding = eksternFakturaStatusDto.feilmelding,
+            faktura = faktura
+        )
+        every { fakturaRepository.save(any()) } returns faktura
+        val manglendeFakturabetalingSlot = slot<ManglendeFakturabetalingDto>()
+
+
+        service.lagreEksternFakturaStatusMelding(eksternFakturaStatusDto)
+
+
+        verify { manglendeFakturabetalingProducer.produserBestillingsmelding(capture(manglendeFakturabetalingSlot)) }
+        manglendeFakturabetalingSlot.captured.run {
+            fakturaserieReferanse shouldBe "321"
+            betalingstatus shouldBe Betalingstatus.DELVIS_BETALT
+            fakturanummer shouldBe "82"
+            datoMottatt shouldBe LocalDate.of(2023, 2, 1)
         }
     }
 }


### PR DESCRIPTION
Denne PR'en fungerer som en extention av https://github.com/navikt/faktureringskomponenten/pull/107. 

Den logikken rundt duplikatsjekken av melding fra OEBS er jeg litt usikker på om det er riktig. Skal ha en gjennomgang med @thanglyphan senere i uken. Derfor har jeg ikke fokusert for mye på det.