### PR TITLE
6130: Endre navn Betalingstatus -> Betalingsstatus

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/EksternFakturaStatusService.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/EksternFakturaStatusService.kt
@@ -7,7 +7,7 @@ import no.nav.faktureringskomponenten.domain.models.FakturaStatus
 import no.nav.faktureringskomponenten.domain.repositories.FakturaRepository
 import no.nav.faktureringskomponenten.exceptions.RessursIkkeFunnetException
 import no.nav.faktureringskomponenten.service.integration.kafka.ManglendeFakturabetalingProducer
-import no.nav.faktureringskomponenten.service.integration.kafka.dto.Betalingstatus
+import no.nav.faktureringskomponenten.service.integration.kafka.dto.Betalingsstatus
 import no.nav.faktureringskomponenten.service.integration.kafka.dto.EksternFakturaStatusDto
 import no.nav.faktureringskomponenten.service.integration.kafka.dto.ManglendeFakturabetalingDto
 import no.nav.faktureringskomponenten.service.mappers.EksternFakturaStatusMapper
@@ -55,15 +55,15 @@ class EksternFakturaStatusService(
             }
 
             if (eksternFakturaStatus.status == FakturaStatus.MANGLENDE_INNBETALING) {
-                val betalingstatus =
-                    if (eksternFakturaStatus.fakturaBelop == eksternFakturaStatus.ubetaltBelop) Betalingstatus.IKKE_BETALT
-                    else Betalingstatus.DELVIS_BETALT
+                val betalingsstatus =
+                    if (eksternFakturaStatus.fakturaBelop == eksternFakturaStatus.ubetaltBelop) Betalingsstatus.IKKE_BETALT
+                    else Betalingsstatus.DELVIS_BETALT
                 manglendeFakturabetalingProducer.produserBestillingsmelding(
                     ManglendeFakturabetalingDto(
                         fakturaserieReferanse = faktura.fakturaserie?.referanse ?: throw NullPointerException(
                             "Fakturaserie på faktura $faktura.id er null"
                         ),
-                        betalingstatus = betalingstatus,
+                        betalingsstatus = betalingsstatus,
                         datoMottatt = eksternFakturaStatus.dato!!,
                         fakturanummer = eksternFakturaStatusDto.fakturaNummer!!
                     )

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/integration/kafka/dto/Betalingsstatus.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/integration/kafka/dto/Betalingsstatus.kt
@@ -1,6 +1,6 @@
 package no.nav.faktureringskomponenten.service.integration.kafka.dto
 
-enum class Betalingstatus {
+enum class Betalingsstatus {
     DELVIS_BETALT,
     IKKE_BETALT,
 }

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/integration/kafka/dto/ManglendeFakturabetalingDto.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/integration/kafka/dto/ManglendeFakturabetalingDto.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class ManglendeFakturabetalingDto(
     var fakturaserieReferanse: String,
-    var betalingstatus: Betalingstatus,
+    var betalingsstatus: Betalingsstatus,
     var datoMottatt: LocalDate,
     var fakturanummer: String
 )

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/EksternFakturaStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/EksternFakturaStatusServiceTest.kt
@@ -10,7 +10,7 @@ import no.nav.faktureringskomponenten.domain.models.Fakturaserie
 import no.nav.faktureringskomponenten.domain.repositories.FakturaRepository
 import no.nav.faktureringskomponenten.exceptions.RessursIkkeFunnetException
 import no.nav.faktureringskomponenten.service.integration.kafka.ManglendeFakturabetalingProducer
-import no.nav.faktureringskomponenten.service.integration.kafka.dto.Betalingstatus
+import no.nav.faktureringskomponenten.service.integration.kafka.dto.Betalingsstatus
 import no.nav.faktureringskomponenten.service.integration.kafka.dto.EksternFakturaStatusDto
 import no.nav.faktureringskomponenten.service.integration.kafka.dto.ManglendeFakturabetalingDto
 import no.nav.faktureringskomponenten.service.mappers.EksternFakturaStatusMapper
@@ -125,7 +125,7 @@ class EksternFakturaStatusServiceTest {
         verify { manglendeFakturabetalingProducer.produserBestillingsmelding(capture(manglendeFakturabetalingSlot)) }
         manglendeFakturabetalingSlot.captured.run {
             fakturaserieReferanse shouldBe "321"
-            betalingstatus shouldBe Betalingstatus.IKKE_BETALT
+            betalingsstatus shouldBe Betalingsstatus.IKKE_BETALT
             fakturanummer shouldBe "82"
             datoMottatt shouldBe LocalDate.of(2023, 2, 1)
         }
@@ -168,7 +168,7 @@ class EksternFakturaStatusServiceTest {
         verify { manglendeFakturabetalingProducer.produserBestillingsmelding(capture(manglendeFakturabetalingSlot)) }
         manglendeFakturabetalingSlot.captured.run {
             fakturaserieReferanse shouldBe "321"
-            betalingstatus shouldBe Betalingstatus.DELVIS_BETALT
+            betalingsstatus shouldBe Betalingsstatus.DELVIS_BETALT
             fakturanummer shouldBe "82"
             datoMottatt shouldBe LocalDate.of(2023, 2, 1)
         }


### PR DESCRIPTION
Ser vi bruker  `...sstatus` overalt i Melosys ellers.

Feil meldt om på Slack: https://nav-it.slack.com/archives/C05AYQKUC0K/p1701252512871039

