### PR TITLE
db-f1-micro, som er default, bør ikke brukes i prod

### DIFF
--- a/nais/nais.yml
+++ b/nais/nais.yml
@@ -14,6 +14,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_15
+        tier: {{database_tier}}
         diskAutoresize: true
         databases:
           - name: {{database_name}}

--- a/nais/vars-prod.json
+++ b/nais/vars-prod.json
@@ -1,6 +1,7 @@
 {
   "app_name": "faktureringskomponenten",
   "database_name": "faktureringskomponenten-db",
+  "database_tier": "db-custom-1-3840",
   "namespace": "teammelosys",
   "ingress": "https://faktureringskomponenten.intern.nav.no",
   "tenant": "nav.no",

--- a/nais/vars-q1.json
+++ b/nais/vars-q1.json
@@ -1,6 +1,7 @@
 {
   "app_name": "faktureringskomponenten-q1",
   "database_name": "faktureringskomponenten-db-q1",
+  "database_tier": "db-g1-small",
   "namespace": "teammelosys",
   "ingress": "https://faktureringskomponenten-q1.intern.dev.nav.no",
   "tenant": "trygdeetaten.no",

--- a/nais/vars-q2.json
+++ b/nais/vars-q2.json
@@ -1,6 +1,7 @@
 {
   "app_name": "faktureringskomponenten-q2",
   "database_name": "faktureringskomponenten-db-q2",
+  "database_tier": "db-g1-small",
   "namespace": "teammelosys",
   "ingress": "https://faktureringskomponenten-q2.intern.dev.nav.no",
   "tenant": "trygdeetaten.no",


### PR DESCRIPTION
Gjelder også db-g1-small

These machine types are configured to use a shared-core CPU, and are
designed to provide low-cost test and development instances only. Don't
use them for production instances.
(https://cloud.google.com/sql/docs/postgres/instance-settings#machine-type-2ndgen)
