### PR TITLE
NOJIRA: Random tall på simulert manglende innbetaling

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/AdminController.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/AdminController.kt
@@ -104,7 +104,7 @@ class AdminController(
 
         val simulertEksternFakturaStatusDto = EksternFakturaStatusDto(
             fakturaReferanseNr = fakturaReferanse,
-            fakturaNummer = "SIMULERT_MANGLENDE_INNBETALING",
+            fakturaNummer = (99990000..99999999).random().toString(),
             fakturaBelop = faktura.totalbeløp(),
             ubetaltBelop = faktura.totalbeløp(),
             status = FakturaStatus.MANGLENDE_INNBETALING,

--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/dto/FakturaResponseDto.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/dto/FakturaResponseDto.kt
@@ -1,13 +1,14 @@
 package no.nav.faktureringskomponenten.controller.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import no.nav.faktureringskomponenten.domain.models.EksternFakturaStatus
 import no.nav.faktureringskomponenten.domain.models.FakturaStatus
-import java.math.BigDecimal
 import java.time.LocalDate
 
 @Schema(description = "Model for en faktura i fakturaserien")
 data class FakturaResponseDto(
+
+    @Schema(description = "Unik identifikator av faktura")
+    val fakturaReferanse: String,
 
     @Schema(description = "Dato for når faktura bestilles til OEBS")
     val datoBestilt: LocalDate,

--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/mapper/ModelDtoMapperExtensions.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/mapper/ModelDtoMapperExtensions.kt
@@ -60,6 +60,7 @@ private val FullmektigDto.tilFullmektig: Fullmektig
 
 private val Faktura.tilResponseDto: FakturaResponseDto
     get() = FakturaResponseDto(
+        fakturaReferanse = this.referanseNr,
         datoBestilt = this.datoBestilt,
         sistOppdatert = this.sistOppdatert,
         status = this.status,


### PR DESCRIPTION
Melosys-API forventer fakturanummer som sifre. Bytter derfor identifikator til et randomt tall mellom 99990000 - 99999999. 
Legger også til fakturareferanse i DTO ettersom det vil gjøre at vi slipper å gå innpå databasen for å hente det hver gang.