### PR TITLE
6376: Returner ny fakturaseriereferanse ved kansellering

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieController.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieController.kt
@@ -105,10 +105,12 @@ class FakturaserieController @Autowired constructor(
     @DeleteMapping("/{referanse}")
     fun kansellerFakturaserie(
         @PathVariable("referanse", required = true) referanse: String,
-    ): HttpStatus {
+    ): ResponseEntity<NyFakturaserieResponseDto> {
         log.info("Mottatt forespørsel om kansellering av fakturaserie: ${referanse}")
 
-        faktureringService.kansellerFakturaserie(referanse)
-        return HttpStatus.NO_CONTENT
+        val nyFakturaserieRefereanse = faktureringService.kansellerFakturaserie(referanse)
+
+        log.info("Kansellert fakturaserie med referanse ${referanse}, Ny fakturaseriereferanse: ${nyFakturaserieRefereanse}")
+        return ResponseEntity.ok(NyFakturaserieResponseDto(nyFakturaserieRefereanse))
     }
 }

--- a/src/test/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieControllerIT.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/controller/FakturaserieControllerIT.kt
@@ -469,7 +469,7 @@ class FakturaserieControllerIT(
             .returnResult().responseBody!!.fakturaserieReferanse
 
         nyFakturaserieReferanse shouldNotBe null
-        nyFakturaserieReferanse shouldNotBe nyFakturaserieReferanse
+        nyFakturaserieReferanse shouldNotBe opprinneligFakturaserieReferanse
     }
 
     @ParameterizedTest(name = "{0} gir feilmelding \"{3}\"")
@@ -608,9 +608,8 @@ class FakturaserieControllerIT(
             .exchange()
 
     private fun deleteKansellerFakturaserieRequest(referanse: String): WebTestClient.ResponseSpec =
-        webClient.post()
+        webClient.delete()
             .uri("/fakturaserier/$referanse")
-            .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .header("Nav-User-Id", NAV_IDENT)
             .headers {


### PR DESCRIPTION
melosys-api forventer ny fakturaseriereferanse når vi kansellerer, mens faktureringskomponenten tidligere returnerte NO_CONTENT (204).

https://jira.adeo.no/browse/MELOSYS-6376