### PR TITLE
NOJIRA: Rydd i tester på bruk av gammel variabelnavn

### DIFF
--- a/src/test/kotlin/no/nav/faktureringskomponenten/TestFacktoryDsl.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/TestFacktoryDsl.kt
@@ -76,7 +76,7 @@ class FakturaBuilder(
     private var fakturaserie: Fakturaserie? = null,
     private var eksternFakturaStatus: MutableList<EksternFakturaStatus> = mutableListOf(),
     private var eksternFakturaNummer: String = "",
-    private var kreditReferanseNr: String = "",
+    private var kredriteringFakturaRef: String = "",
     private var referertFakturaVedAvregning: Faktura? = null
 ) {
     fun referanseNr(referanseNr: String) = apply { this.referanseNr = referanseNr }
@@ -97,7 +97,7 @@ class FakturaBuilder(
     fun eksternFakturaNummer(eksternFakturaNummer: String) =
         apply { this.eksternFakturaNummer = eksternFakturaNummer }
 
-    fun kreditReferanseNr(kreditReferanseNr: String) = apply { this.kreditReferanseNr = kreditReferanseNr }
+    fun kredriteringFakturaRef(kredriteringFakturaRef: String) = apply { this.kredriteringFakturaRef = kredriteringFakturaRef }
 
     fun referertFakturaVedAvregning(referertFakturaVedAvregning: Faktura) =
         apply { this.referertFakturaVedAvregning = referertFakturaVedAvregning }
@@ -110,7 +110,7 @@ class FakturaBuilder(
         fakturaserie = fakturaserie,
         eksternFakturaStatus = eksternFakturaStatus,
         eksternFakturaNummer = eksternFakturaNummer,
-        krediteringFakturaRef = kreditReferanseNr,
+        krediteringFakturaRef = kredriteringFakturaRef,
         referertFakturaVedAvregning = referertFakturaVedAvregning
     )
 }

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaBestillingServiceTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaBestillingServiceTest.kt
@@ -154,10 +154,10 @@ class FakturaBestillingServiceTest {
         val fakturaserie = lagFakturaserie {
             faktura(
                 lagFaktura {
-                    kreditReferanseNr(ULID.randomULID())
+                    kredriteringFakturaRef(ULID.randomULID())
                 },
                 lagFaktura {
-                    kreditReferanseNr(ULID.randomULID())
+                    kredriteringFakturaRef(ULID.randomULID())
                 }
             )
         }

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/mappers/FakturaBestiltDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/mappers/FakturaBestiltDtoMapperTest.kt
@@ -182,7 +182,7 @@ class FakturaBestiltDtoMapperTest {
         val testFakturaserie = lagFakturaserie {
             faktura(
                 lagFaktura {
-                    kreditReferanseNr("45678913")
+                    kredriteringFakturaRef("45678913")
                 }
             )
         }


### PR DESCRIPTION
Rydder i bruk av navnet kreditreferanseNr som er faset ut.
 
https://github.com/navikt/faktureringskomponenten/pull/165 