### PR TITLE
6820 fjern errorlogging

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieService.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieService.kt
@@ -45,7 +45,7 @@ class FakturaserieService(
             fakturaserieRepository.findAllByFodselsnummer(fakturaserie.fodselsnummer)
                 .filter { it.erAktiv() }
         if (listeAvAktiveFakturaserierForFodselsnummer.size > 1) {
-            log.error("Det finnes flere aktive fakturaserier for fødselsnummer av fakturaserie ${fakturaserie.referanse}")
+            log.warn("Det finnes flere aktive fakturaserier for fødselsnummer av fakturaserie ${fakturaserie.referanse}")
         }
         return fakturaserie.referanse
     }


### PR DESCRIPTION
Ikke en teknisk feil, men tyder på at saksbehandlere har opprettet flere saker enn nødvendig ref. https://jira.adeo.no/browse/MELOSYS-6820

(Ble innført i https://github.com/navikt/faktureringskomponenten/pull/174)