### PR TITLE
6980 refaktorering når fakturaserie erstattes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 group = "no.nav"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_17
-
+extra["junit-jupiter.version"] = "5.11.3"
 
 repositories {
     mavenCentral()
@@ -81,7 +81,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.mockito", module = "mockito-core")
     }
-    testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("no.nav.security:token-validation-spring-test:${dependencyVersions.tokenSupportVersion}")
     testImplementation("io.kotest:kotest-assertions-core-jvm:${dependencyVersions.kotestVersion}")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaGenerator.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaGenerator.kt
@@ -3,14 +3,17 @@ package no.nav.faktureringskomponenten.service
 import io.getunleash.Unleash
 import no.nav.faktureringskomponenten.domain.models.Faktura
 import no.nav.faktureringskomponenten.domain.models.FakturaLinje
+import no.nav.faktureringskomponenten.domain.models.FakturaserieIntervall
 import no.nav.faktureringskomponenten.domain.models.FakturaseriePeriode
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import org.threeten.extra.LocalDateRange
 import ulid.ULID
 import java.time.LocalDate
-import java.time.Month
-import java.time.temporal.IsoFields
 
+/**
+ * Genererer fakturaer for en hel Fakturaserie basert på periodisering og faktureringsgrunnlag.
+ */
 @Component
 class FakturaGenerator(
     private val fakturalinjeGenerator: FakturaLinjeGenerator,
@@ -20,49 +23,135 @@ class FakturaGenerator(
     @Value("\${NAIS_CLUSTER_NAME}")
     private lateinit var naisClusterName: String
 
+    /**
+     * Genererer fakturaer basert på gitte perioder og faktureringsgrunnlag.
+     * Historiske perioder (til og med dagens dato) grupperes per år,
+     * mens fremtidige perioder faktureres per periode definert i 'periodisering'.
+     *
+     * @param periodisering Liste av perioder som definerer fakturaoppdelingen (typisk kvartalsvis, men kan være månedlig)
+     * @param fakturaseriePerioder Liste av perioder som definerer faktureringsgrunnlaget og enhetspris per måned
+     * @return Liste av fakturaer gruppert etter historiske (årlig) og fremtidige (per periode) perioder
+     */
     fun lagFakturaerFor(
         periodisering: List<Pair<LocalDate, LocalDate>>,
-        fakturaseriePerioder: List<FakturaseriePeriode>
+        fakturaseriePerioder: List<FakturaseriePeriode>,
+        intervall: FakturaserieIntervall
     ): List<Faktura> {
-        // val sluttDatoForPeriodisering = periodisering.last().second
-        return periodisering.fold(
-            initial = emptyList<FakturaLinje>() to emptyList<Faktura>()
-        ) { (gjeldendeLinjer, akkumulerteFakturaer), (periodeStart, periodeSlutt) ->
-            val nyeFakturaLinjer = lagFakturaLinjerForPeriode(
-                periodeStart, periodeSlutt, fakturaseriePerioder, periodisering.last().second
-            )
-            val oppdaterteFakturaLinjer = gjeldendeLinjer + nyeFakturaLinjer
+        validerPerioder(periodisering, fakturaseriePerioder)
 
-            if ((periodeSlutt >= dagensDato() || erSisteDagIÅret(periodeSlutt)) && oppdaterteFakturaLinjer.isNotEmpty()) {
-                val nyFaktura = tilFaktura(periodeStart, oppdaterteFakturaLinjer)
-                emptyList<FakturaLinje>() to akkumulerteFakturaer + nyFaktura
-            } else if (periodeSlutt == periodisering.last().second && oppdaterteFakturaLinjer.isNotEmpty()) {
-                val sisteFaktura = tilFaktura(oppdaterteFakturaLinjer.minOf { it.periodeFra }, oppdaterteFakturaLinjer)
-                emptyList<FakturaLinje>() to akkumulerteFakturaer + sisteFaktura
-            } else {
-                oppdaterteFakturaLinjer to akkumulerteFakturaer
+        val dagensDato = dagensDato()
+
+        val (historiskePerioder, fremtidigePerioder) = periodisering.partition { (startDato, _) ->
+            startDato.isBefore(dagensDato)
+        }
+
+        return lagFakturaerForHistoriskePerioder(historiskePerioder, fakturaseriePerioder, intervall) +
+            lagFremtidigeFakturaer(fremtidigePerioder, fakturaseriePerioder, intervall)
+    }
+
+    /**
+     * Lager fakturaer for historiske perioder (perioder som har forfalt).
+     * Historiske perioder blir gruppert per år og det lages én faktura per år.
+     */
+    private fun lagFakturaerForHistoriskePerioder(
+        historiskePerioder: List<Pair<LocalDate, LocalDate>>,
+        fakturaseriePerioder: List<FakturaseriePeriode>,
+        intervall: FakturaserieIntervall
+    ): List<Faktura> {
+        if (historiskePerioder.isEmpty()) return emptyList()
+        return historiskePerioder
+            // Grupper perioder per år siden det lages én faktura per år.
+            .groupBy { (_, sluttDato) -> sluttDato.year }
+            // Filtrer bort år uten fakturering, hvis det er opphold i faktureringen
+            .filterÅrMedFakturaPerioder(fakturaseriePerioder)
+            // Lager en fakturalinje for hver periode i året
+            .mapValues { (_, perioderForÅr) ->
+                perioderForÅr.flatMap { (periodeStart, periodeSlutt) ->
+                    lagFakturaLinjerForPeriode(
+                        periodeStart,
+                        periodeSlutt,
+                        fakturaseriePerioder
+                    )
+                }
             }
-        }.second
+            // Lag én faktura per år med alle perioder samlet
+            .mapNotNull { (_, fakturaLinjer) ->
+                if (fakturaLinjer.isEmpty()) {
+                    null // Lag kun fakturaer som inneholder linjer
+                } else {
+                    tilFaktura(
+                        fakturaLinjer.sortedByDescending { it.periodeFra },
+                        intervall
+                    )
+                }
+            }
+    }
+
+    /**
+     * Lager fakturaer for fremtidige perioder.
+     * Hver periode i @param fremtidigePerioder får sin egen faktura hvis den overlapper med en FakturaseriePeriode.
+     */
+    private fun lagFremtidigeFakturaer(
+        fremtidigePerioder: List<Pair<LocalDate, LocalDate>>,
+        fakturaseriePerioder: List<FakturaseriePeriode>,
+        intervall: FakturaserieIntervall
+    ): List<Faktura> {
+        if (fremtidigePerioder.isEmpty()) return emptyList()
+        return fremtidigePerioder
+            // Filtrerer fremtidige perioder som overlapper med faktureringsgrunnlaget
+            .filter { (start, slutt) ->
+                val periodeRange = LocalDateRange.ofClosed(start, slutt)
+                fakturaseriePerioder.any { periode ->
+                    LocalDateRange.ofClosed(periode.startDato, periode.sluttDato).overlaps(periodeRange)
+                }
+            }
+            // Lag en Map med periode -> fakturalinjer
+            .associateWith { lagFakturaLinjerForPeriode(it.first, it.second, fakturaseriePerioder) }
+            // Lag en faktura per periode hvis det finnes fakturalinjer
+            .mapNotNull { (_, fakturaLinjer) ->
+                if (fakturaLinjer.isEmpty()) {
+                    null
+                } else {
+                    tilFaktura(
+                        fakturaLinjer.sortedByDescending { it.periodeFra },
+                        intervall
+                    )
+                }
+            }
+    }
+
+    /**
+     * Filtrerer bort år som ikke har noen overlappende fakturaperioder.
+     * Dette er nødvendig for å håndtere opphold i faktureringsperioder,
+     * f.eks. hvis det ikke skal faktureres for et helt år.
+     */
+    private fun Map<Int, List<Pair<LocalDate, LocalDate>>>.filterÅrMedFakturaPerioder(
+        fakturaseriePerioder: List<FakturaseriePeriode>
+    ): Map<Int, List<Pair<LocalDate, LocalDate>>> {
+        return filter { (år, _) ->
+            val årRange = LocalDateRange.ofClosed(
+                LocalDate.of(år, 1, 1),
+                LocalDate.of(år, 12, 31)
+            )
+            fakturaseriePerioder.any { periode ->
+                LocalDateRange.ofClosed(periode.startDato, periode.sluttDato).overlaps(årRange)
+            }
+        }
     }
 
     private fun lagFakturaLinjerForPeriode(
-        gjeldendeFaktureringStartDato: LocalDate,
-        gjeldendeFaktureringSluttDato: LocalDate,
-        fakturaseriePerioder: List<FakturaseriePeriode>,
-        sluttDatoForHelePerioden: LocalDate
+        periodeStart: LocalDate,
+        periodeSlutt: LocalDate,
+        fakturaseriePerioder: List<FakturaseriePeriode>
     ): List<FakturaLinje> = fakturalinjeGenerator.lagFakturaLinjer(
         perioder = fakturaseriePerioder,
-        faktureringFra = gjeldendeFaktureringStartDato,
-        faktureringTil = sluttDatoFra(gjeldendeFaktureringSluttDato, sluttDatoForHelePerioden)
+        faktureringFra = periodeStart,
+        faktureringTil = periodeSlutt
     )
 
-    private fun sluttDatoFra(sisteDagAvPeriode: LocalDate, sluttDatoForHelePerioden: LocalDate) =
-        if (sisteDagAvPeriode > sluttDatoForHelePerioden) sluttDatoForHelePerioden else sisteDagAvPeriode
 
-    private fun erSisteDagIÅret(dato: LocalDate): Boolean = dato.month == Month.DECEMBER && dato.dayOfMonth == 31
-
-    private fun tilFaktura(fakturaStartDato: LocalDate, fakturaLinjer: List<FakturaLinje>): Faktura {
-        val bestillingsdato = utledBestillingsdato(fakturaStartDato)
+    private fun tilFaktura(fakturaLinjer: List<FakturaLinje>, intervall: FakturaserieIntervall): Faktura {
+        val bestillingsdato = utledBestillingsdato(fakturaLinjer.minOf { it.periodeFra }, intervall)
 
         return Faktura(
             null,
@@ -71,38 +160,57 @@ class FakturaGenerator(
             fakturaLinje = fakturaLinjer.sortedByDescending { it.periodeFra })
     }
 
-    private fun erNesteKvartalOgKvartalsbestillingHarKjørt(
-        fakturaStartDato: LocalDate,
-        dagensDato: LocalDate,
-    ): Boolean {
-        val erNesteKvartal = dagensDato < fakturaStartDato && dagensDato[IsoFields.QUARTER_OF_YEAR]
-            .plus(1) % 4 == fakturaStartDato[IsoFields.QUARTER_OF_YEAR] % 4
-        val sisteMånedIDagensKvartal = dagensDato.month.firstMonthOfQuarter().plus(2)
-        val kvartalsBestillingHarKjørt =
-            dagensDato > LocalDate.now().withMonth(sisteMånedIDagensKvartal.value).withDayOfMonth(19)
-        val datoErEtter19Desember = dagensDato >= LocalDate.now().withMonth(12).withDayOfMonth(19)
-        val fakturaStartDatoErÅretEtterOgFørsteKvartal =
-            fakturaStartDato.year == dagensDato.plusYears(1).year && fakturaStartDato.month.value <= 3
-        return erNesteKvartal && kvartalsBestillingHarKjørt && (fakturaStartDato.year == dagensDato.year || (datoErEtter19Desember && fakturaStartDatoErÅretEtterOgFørsteKvartal))
+    private fun validerPerioder(
+        periodisering: List<Pair<LocalDate, LocalDate>>,
+        fakturaseriePerioder: List<FakturaseriePeriode>
+    ) {
+        if (periodisering.isEmpty() || fakturaseriePerioder.isEmpty()) return
+        val periodiseringStart = periodisering.minOf { it.first }
+        val periodiseringSlutt = periodisering.maxOf { it.second }
+
+        val fakturaPeriodeStart = fakturaseriePerioder.minOf { it.startDato }
+        val fakturaPeriodeSlutt = fakturaseriePerioder.maxOf { it.sluttDato }
+
+        require(
+            !periodiseringStart.isBefore(fakturaPeriodeStart) &&
+                !periodiseringSlutt.isAfter(fakturaPeriodeSlutt)
+        ) {
+            "Periodisering ($periodiseringStart til $periodiseringSlutt) må være innenfor faktureringsperiodene ($fakturaPeriodeStart til $fakturaPeriodeSlutt)"
+        }
     }
 
-    private fun utledBestillingsdato(fakturaStartDato: LocalDate): LocalDate {
+    private fun utledBestillingsdato(fakturaStartDato: LocalDate, intervall: FakturaserieIntervall): LocalDate {
         if (unleash.isEnabled("melosys.faktureringskomponent.send_faktura_instant") && naisClusterName == NAIS_CLUSTER_NAME_DEV) {
             return dagensDato()
         }
 
-        if (fakturaStartDato <= dagensDato() || erInneværendeÅrOgKvartal(fakturaStartDato, dagensDato()) ||
-            erNesteKvartalOgKvartalsbestillingHarKjørt(fakturaStartDato, dagensDato())
-        ) {
+        // Hvis fakturaen starter i fortiden eller i dag
+        if (fakturaStartDato <= dagensDato()) {
             return dagensDato().plusDays(forsteFakturaOffsettMedDager)
         }
-        val førstMånedIKvartal = fakturaStartDato.month.firstMonthOfQuarter()
-        return fakturaStartDato.withMonth(førstMånedIKvartal.value).minusMonths(1).withDayOfMonth(19)
+
+        // Hvis bestillingsdato for perioden har kjørt
+        if (harBestillingsdatoKjørt(fakturaStartDato, intervall)) {
+            return dagensDato().plusDays(forsteFakturaOffsettMedDager)
+        }
+
+        // Planlegg for den 19. i måneden før periodestart hvis intervall er MÅNEDLIG. Ellers 19. i måneden før kvartalet dersom intervall er KVARTAL
+        return when (intervall) {
+            FakturaserieIntervall.MANEDLIG -> fakturaStartDato.withDayOfMonth(1).minusMonths(1).withDayOfMonth(19)
+            FakturaserieIntervall.KVARTAL -> fakturaStartDato.withMonth(fakturaStartDato.month.firstMonthOfQuarter().value).withDayOfMonth(1).minusMonths(1).withDayOfMonth(19)
+            FakturaserieIntervall.SINGEL -> throw IllegalArgumentException("Singelintervall er ikke støttet")
+        }
     }
 
-    private fun erInneværendeÅrOgKvartal(datoA: LocalDate, datoB: LocalDate): Boolean {
-        return datoA[IsoFields.QUARTER_OF_YEAR] == datoB[IsoFields.QUARTER_OF_YEAR]
-                && datoA.year == datoB.year
+    private fun harBestillingsdatoKjørt(fakturaStartDato: LocalDate, intervall: FakturaserieIntervall): Boolean {
+        val førsteIPerioden = when(intervall) {
+            FakturaserieIntervall.MANEDLIG -> fakturaStartDato.withDayOfMonth(1)
+            FakturaserieIntervall.KVARTAL -> fakturaStartDato.withMonth(fakturaStartDato.month.firstMonthOfQuarter().value).withDayOfMonth(1)
+            FakturaserieIntervall.SINGEL -> throw IllegalArgumentException("Singelintervall er ikke støttet")
+        }
+
+        val bestillingsDato = førsteIPerioden.minusMonths(1).withDayOfMonth(19)
+        return dagensDato() >= bestillingsDato
     }
 
     protected fun dagensDato(): LocalDate = LocalDate.now()

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaGenerator.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaGenerator.kt
@@ -20,17 +20,6 @@ class FakturaGenerator(
     @Value("\${NAIS_CLUSTER_NAME}")
     private lateinit var naisClusterName: String
 
-    // FIXME: Dette er en midlertidig løsning for å fikse https://jira.adeo.no/browse/MELOSYS-6957, metoden tar ikke hensyn til dagens dato
-    fun lagFaktura(
-        startDato: LocalDate,
-        sluttDato: LocalDate,
-        fakturaseriePerioder: List<FakturaseriePeriode>
-    ): Faktura {
-        val fakturaLinjer = lagFakturaLinjerForPeriode(startDato, sluttDato, fakturaseriePerioder, sluttDato)
-
-        return tilFaktura(startDato, fakturaLinjer)
-    }
-
     fun lagFakturaerFor(
         periodisering: List<Pair<LocalDate, LocalDate>>,
         fakturaseriePerioder: List<FakturaseriePeriode>

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaIntervallPeriodisering.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaIntervallPeriodisering.kt
@@ -1,0 +1,26 @@
+package no.nav.faktureringskomponenten.service
+
+import no.nav.faktureringskomponenten.domain.models.FakturaserieIntervall
+import java.time.LocalDate
+import java.time.temporal.IsoFields
+import java.time.temporal.TemporalAdjusters
+
+object FakturaIntervallPeriodisering {
+    fun genererPeriodisering(
+        startDatoForPerioden: LocalDate,
+        sluttDatoForPerioden: LocalDate,
+        faktureringsintervall: FakturaserieIntervall
+    ): List<Pair<LocalDate, LocalDate>> = generateSequence(startDatoForPerioden) { startDato ->
+        sluttDatoFor(startDato, faktureringsintervall).plusDays(1)
+    }.takeWhile { it <= sluttDatoForPerioden }
+        .map { startDato ->
+            val sluttDato = minOf(sluttDatoFor(startDato, faktureringsintervall), sluttDatoForPerioden)
+            startDato to sluttDato
+        }.toList()
+
+    private fun sluttDatoFor(startDato: LocalDate, intervall: FakturaserieIntervall): LocalDate = when (intervall) {
+        FakturaserieIntervall.MANEDLIG -> startDato.withDayOfMonth(startDato.lengthOfMonth())
+        FakturaserieIntervall.KVARTAL -> startDato.withMonth(startDato[IsoFields.QUARTER_OF_YEAR] * 3).with(TemporalAdjusters.lastDayOfMonth())
+        FakturaserieIntervall.SINGEL -> throw IllegalArgumentException("Singelintervall er ikke støttet")
+    }
+}

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaLinjeGenerator.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaLinjeGenerator.kt
@@ -10,8 +10,6 @@ import java.time.format.DateTimeFormatter
 
 @Component
 class FakturaLinjeGenerator {
-    private val DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy")
-
     fun lagFakturaLinjer(
         perioder: List<FakturaseriePeriode>,
         faktureringFra: LocalDate,
@@ -39,5 +37,9 @@ class FakturaLinjeGenerator {
                 enhetsprisPerManed = it.enhetsprisPerManed
             )
         }.toList()
+    }
+
+    companion object {
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy")
     }
 }

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieGenerator.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieGenerator.kt
@@ -142,11 +142,7 @@ class FakturaserieGenerator(
         private fun sluttDatoFor(startDato: LocalDate, intervall: FakturaserieIntervall): LocalDate = when (intervall) {
             FakturaserieIntervall.MANEDLIG -> startDato.withDayOfMonth(startDato.lengthOfMonth())
             FakturaserieIntervall.KVARTAL -> startDato.withMonth(startDato[IsoFields.QUARTER_OF_YEAR] * 3).with(TemporalAdjusters.lastDayOfMonth())
-            FakturaserieIntervall.SINGEL -> SingleErIkkeStøttet()
-        }
-
-        private fun SingleErIkkeStøttet(): Nothing {
-            throw IllegalArgumentException("Singelintervall er ikke støttet")
+            FakturaserieIntervall.SINGEL -> throw IllegalArgumentException("Singelintervall er ikke støttet")
         }
 
         fun LocalDateRange.substract(other: LocalDateRange): List<LocalDateRange> {

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieGenerator.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/FakturaserieGenerator.kt
@@ -27,8 +27,8 @@ class FakturaserieGenerator(
             finnStartDatoForSamletPeriode(avregningsfakturaSistePeriodeTil, startDato, fakturaserieDto)
         val sluttDatoForSamletPeriode = fakturaserieDto.perioder.maxBy { it.sluttDato }.sluttDato
 
-        val periodisering = genererPeriodisering(startDatoForSamletPeriode, sluttDatoForSamletPeriode, fakturaserieDto.intervall)
-        val fakturaerForSamletPeriode = fakturaGenerator.lagFakturaerFor(periodisering, fakturaserieDto.perioder)
+        val periodisering = FakturaIntervallPeriodisering.genererPeriodisering(startDatoForSamletPeriode, sluttDatoForSamletPeriode, fakturaserieDto.intervall)
+        val fakturaerForSamletPeriode = fakturaGenerator.lagFakturaerFor(periodisering, fakturaserieDto.perioder, fakturaserieDto.intervall)
 
         return Fakturaserie(
             id = null,
@@ -68,7 +68,7 @@ class FakturaserieGenerator(
         fakturaserieDto: FakturaserieDto,
         avregningsfakturaer: List<Faktura>
     ): List<Faktura> {
-        val fellesPeriodisering = genererPeriodisering(
+        val fellesPeriodisering = FakturaIntervallPeriodisering.genererPeriodisering(
             fakturaserieDto.perioder.minBy { it.startDato }.startDato,
             fakturaserieDto.perioder.maxBy { it.sluttDato }.sluttDato,
             fakturaserieDto.intervall
@@ -82,7 +82,8 @@ class FakturaserieGenerator(
 
         val nyeFakturaerForNyePerioder: List<Faktura> = fakturaGenerator.lagFakturaerFor(
             periodiseringUtenAvregning,
-            fakturaserieDto.perioder
+            fakturaserieDto.perioder,
+            fakturaserieDto.intervall
         )
         return nyeFakturaerForNyePerioder
     }
@@ -127,24 +128,6 @@ class FakturaserieGenerator(
     }
 
     companion object {
-        fun genererPeriodisering(
-            startDatoForPerioden: LocalDate,
-            sluttDatoForPerioden: LocalDate,
-            faktureringsintervall: FakturaserieIntervall
-        ): List<Pair<LocalDate, LocalDate>> = generateSequence(startDatoForPerioden) { startDato ->
-            sluttDatoFor(startDato, faktureringsintervall).plusDays(1)
-        }.takeWhile { it <= sluttDatoForPerioden }
-            .map { startDato ->
-                val sluttDato = minOf(sluttDatoFor(startDato, faktureringsintervall), sluttDatoForPerioden)
-                startDato to sluttDato
-            }.toList()
-
-        private fun sluttDatoFor(startDato: LocalDate, intervall: FakturaserieIntervall): LocalDate = when (intervall) {
-            FakturaserieIntervall.MANEDLIG -> startDato.withDayOfMonth(startDato.lengthOfMonth())
-            FakturaserieIntervall.KVARTAL -> startDato.withMonth(startDato[IsoFields.QUARTER_OF_YEAR] * 3).with(TemporalAdjusters.lastDayOfMonth())
-            FakturaserieIntervall.SINGEL -> throw IllegalArgumentException("Singelintervall er ikke støttet")
-        }
-
         fun LocalDateRange.substract(other: LocalDateRange): List<LocalDateRange> {
             if (!isConnected(other)) return listOf(this)
             return buildList {

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaGeneratorParameterizedTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaGeneratorParameterizedTest.kt
@@ -1,0 +1,416 @@
+package no.nav.faktureringskomponenten.service
+
+import io.getunleash.FakeUnleash
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import no.nav.faktureringskomponenten.domain.models.FakturaserieIntervall
+import no.nav.faktureringskomponenten.domain.models.FakturaseriePeriode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.argumentSet
+import org.junit.jupiter.params.provider.MethodSource
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FakturaGeneratorParameterizedTest {
+
+    private val fakturaLinjeGenerator = FakturaLinjeGenerator()
+    private val unleash = FakeUnleash().also {
+        it.enableAllExcept("melosys.faktureringskomponent.send_faktura_instant")
+    }
+    private val generator = FakturaGenerator(fakturaLinjeGenerator, unleash, 0)
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(LocalDate::class)
+    }
+
+    data class DateTestCase(
+        val description: String,
+        val dagensDato: LocalDate,
+        val perioder: List<FakturaseriePeriode>,
+        val intervall: FakturaserieIntervall,
+        val expectedDatoBestilt: List<LocalDate>
+    )
+
+    data class PeriodTestCase(
+        val description: String,
+        val dagensDato: LocalDate,
+        val perioder: List<FakturaseriePeriode>,
+        val intervall: FakturaserieIntervall,
+        val expectedPerioder: List<Pair<LocalDate, LocalDate>>
+    )
+
+    data class BelopTestCase(
+        val description: String,
+        val dagensDato: LocalDate,
+        val perioder: List<FakturaseriePeriode>,
+        val intervall: FakturaserieIntervall,
+        val expectedBelopPerFaktura: List<ExpectedBelop>
+    )
+
+    data class ExpectedBelop(
+        val periodeFra: LocalDate,
+        val periodeTil: LocalDate,
+        val belop: BigDecimal
+    )
+
+    @ParameterizedTest(name = "{index} {argumentSetName}")
+    @MethodSource("belopTestData")
+    @DisplayName("Test beløpsberegning for delvise perioder")
+    fun `test beløpsberegning for delvise perioder`(testCase: BelopTestCase) {
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns testCase.dagensDato
+
+        val periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+            testCase.perioder.minOf { it.startDato },
+            testCase.perioder.maxOf { it.sluttDato },
+            testCase.intervall
+        )
+
+        val fakturaer = generator.lagFakturaerFor(periodisering, testCase.perioder, testCase.intervall)
+
+        return fakturaer.forEachIndexed { index, faktura ->
+            val expected = testCase.expectedBelopPerFaktura[index]
+            faktura.getPeriodeFra() shouldBe expected.periodeFra
+            faktura.getPeriodeTil() shouldBe expected.periodeTil
+            faktura.fakturaLinje.sumOf { it.belop } shouldBe expected.belop
+        }
+    }
+
+
+    @ParameterizedTest(name = "{index} {argumentSetName}")
+    @MethodSource("datoBestiltTestData")
+    @DisplayName("Test ulike scenarioer for dato bestilt")
+    fun `test dato bestilt scenarios`(testCase: DateTestCase) {
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns testCase.dagensDato
+
+        val periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+            testCase.perioder.minOf { it.startDato },
+            testCase.perioder.maxOf { it.sluttDato },
+            testCase.intervall
+        )
+
+        val fakturaer = generator.lagFakturaerFor(periodisering, testCase.perioder, testCase.intervall)
+
+        fakturaer.shouldHaveSize(testCase.expectedDatoBestilt.size)
+        fakturaer.map { it.datoBestilt }.shouldContainExactlyInAnyOrder(testCase.expectedDatoBestilt)
+    }
+
+    @ParameterizedTest(name = "{index} {argumentSetName}")
+    @MethodSource("periodTestData")
+    @DisplayName("Test ulike scenarioer for periodebehandling")
+    fun `test period handling scenarios`(testCase: PeriodTestCase) {
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns testCase.dagensDato
+
+        val periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+            testCase.perioder.minOf { it.startDato },
+            testCase.perioder.maxOf { it.sluttDato },
+            testCase.intervall
+        )
+
+        val fakturaer = generator.lagFakturaerFor(periodisering, testCase.perioder, testCase.intervall)
+
+        fakturaer.shouldHaveSize(testCase.expectedPerioder.size)
+        fakturaer.map { it.getPeriodeFra() to it.getPeriodeTil() }
+            .shouldContainExactlyInAnyOrder(testCase.expectedPerioder)
+    }
+
+    private fun datoBestiltTestData() = listOf(
+        // Test case: Kvartalsvis fakturering, fremtidig periode
+        DateTestCase(
+            description = "Kvartalsvis fakturering for fremtidig periode",
+            dagensDato = LocalDate.of(2024, 1, 15),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2024, 4, 1),
+                    sluttDato = LocalDate.of(2024, 12, 31),
+                    beskrivelse = "Test periode 1"
+                )
+            ),
+            intervall = FakturaserieIntervall.KVARTAL,
+            expectedDatoBestilt = listOf(
+                LocalDate.of(2024, 3, 19),
+                LocalDate.of(2024, 6, 19),
+                LocalDate.of(2024, 9, 19)
+            )
+        ),
+
+        // Test case: Månedsvis fakturering, blandet historisk og fremtidig
+        DateTestCase(
+            description = "Månedsvis fakturering med historiske og fremtidige perioder",
+            dagensDato = LocalDate.of(2024, 1, 15),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2023, 12, 1),
+                    sluttDato = LocalDate.of(2024, 3, 31),
+                    beskrivelse = "Test periode 2"
+                )
+            ),
+            intervall = FakturaserieIntervall.MANEDLIG,
+            expectedDatoBestilt = listOf(
+                LocalDate.of(2024, 1, 15),
+                LocalDate.of(2024, 1, 15),
+                LocalDate.of(2024, 1, 19),
+                LocalDate.of(2024, 2, 19)
+            )
+        ),
+
+        // Test case: Kvartalsvis på årsskifte
+        DateTestCase(
+            description = "Kvartalsvis fakturering over årsskifte",
+            dagensDato = LocalDate.of(2023, 12, 20),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2023, 12, 1),
+                    sluttDato = LocalDate.of(2024, 3, 31),
+                    beskrivelse = "Test periode 3"
+                )
+            ),
+            intervall = FakturaserieIntervall.KVARTAL,
+            expectedDatoBestilt = listOf(
+                LocalDate.of(2023, 12, 20),
+                LocalDate.of(2023, 12, 20)
+            )
+        )
+    ).map { argumentSet(it.description, it) }
+
+    private fun periodTestData() = listOf(
+        // Test case: Overlappende perioder
+        PeriodTestCase(
+            description = "Overlappende perioder",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2024, 1, 1),
+                    sluttDato = LocalDate.of(2024, 3, 31),
+                    beskrivelse = "Periode 1"
+                ),
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("2000"),
+                    startDato = LocalDate.of(2024, 3, 15),
+                    sluttDato = LocalDate.of(2024, 6, 30),
+                    beskrivelse = "Periode 2"
+                )
+            ),
+            intervall = FakturaserieIntervall.KVARTAL,
+            expectedPerioder = listOf(
+                LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 3, 31),
+                LocalDate.of(2024, 4, 1) to LocalDate.of(2024, 6, 30)
+            )
+        ),
+
+        // Test case: Perioder med opphold
+        PeriodTestCase(
+            description = "Perioder med opphold",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2024, 1, 1),
+                    sluttDato = LocalDate.of(2024, 3, 31),
+                    beskrivelse = "Periode 1"
+                ),
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2024, 7, 1),
+                    sluttDato = LocalDate.of(2024, 9, 30),
+                    beskrivelse = "Periode 2"
+                )
+            ),
+            intervall = FakturaserieIntervall.KVARTAL,
+            expectedPerioder = listOf(
+                LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 3, 31),
+                LocalDate.of(2024, 7, 1) to LocalDate.of(2024, 9, 30)
+            )
+        ),
+
+        // Test case: Delvis måned
+        PeriodTestCase(
+            description = "Periode starter midt i måneden",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2024, 1, 15),
+                    sluttDato = LocalDate.of(2024, 3, 31),
+                    beskrivelse = "Delvis måned"
+                )
+            ),
+            intervall = FakturaserieIntervall.MANEDLIG,
+            expectedPerioder = listOf(
+                LocalDate.of(2024, 1, 15) to LocalDate.of(2024, 1, 31),
+                LocalDate.of(2024, 2, 1) to LocalDate.of(2024, 2, 29),
+                LocalDate.of(2024, 3, 1) to LocalDate.of(2024, 3, 31)
+            )
+        ),
+
+        // Test case: Skuddårhåndtering
+        PeriodTestCase(
+            description = "Skuddår håndtering 2024",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2024, 2, 1),
+                    sluttDato = LocalDate.of(2024, 3, 15),
+                    beskrivelse = "Skuddår periode"
+                )
+            ),
+            intervall = FakturaserieIntervall.MANEDLIG,
+            expectedPerioder = listOf(
+                LocalDate.of(2024, 2, 1) to LocalDate.of(2024, 2, 29),
+                LocalDate.of(2024, 3, 1) to LocalDate.of(2024, 3, 15)
+            )
+        ),
+
+        PeriodTestCase(
+            description = "Årsskifte med delvis kvartaler",
+            dagensDato = LocalDate.of(2023, 12, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2023, 11, 15),
+                    sluttDato = LocalDate.of(2024, 2, 15),
+                    beskrivelse = "Årsskifte periode"
+                )
+            ),
+            intervall = FakturaserieIntervall.KVARTAL,
+            expectedPerioder = listOf(
+                LocalDate.of(2023, 11, 15) to LocalDate.of(2023, 12, 31),
+                LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 2, 15)
+            )
+        ),
+
+        PeriodTestCase(
+            description = "Tre overlappende perioder med ulike priser",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("1000"),
+                    startDato = LocalDate.of(2024, 1, 1),
+                    sluttDato = LocalDate.of(2024, 4, 30),
+                    beskrivelse = "Periode 1"
+                ),
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("2000"),
+                    startDato = LocalDate.of(2024, 3, 15),
+                    sluttDato = LocalDate.of(2024, 7, 15),
+                    beskrivelse = "Periode 2"
+                ),
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("3000"),
+                    startDato = LocalDate.of(2024, 6, 1),
+                    sluttDato = LocalDate.of(2024, 9, 30),
+                    beskrivelse = "Periode 3"
+                )
+            ),
+            intervall = FakturaserieIntervall.KVARTAL,
+            expectedPerioder = listOf(
+                LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 3, 31),
+                LocalDate.of(2024, 4, 1) to LocalDate.of(2024, 6, 30),
+                LocalDate.of(2024, 7, 1) to LocalDate.of(2024, 9, 30)
+            )
+        ),
+
+        // Test case for periode som starter siste dag i måneden
+        PeriodTestCase(
+            description = "Periode starter siste dag i måneder med ulik lengde",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("30000"),  // 1000 kr per dag
+                    startDato = LocalDate.of(2024, 1, 31),     // 31 dager
+                    sluttDato = LocalDate.of(2024, 4, 30),     // 30 dager
+                    beskrivelse = "Test periode siste dag"
+                )
+            ),
+            intervall = FakturaserieIntervall.MANEDLIG,
+            expectedPerioder = listOf(
+                LocalDate.of(2024, 1, 31) to LocalDate.of(2024, 1, 31),  // 1 dag i januar
+                LocalDate.of(2024, 2, 1) to LocalDate.of(2024, 2, 29),   // hele februar (skuddår)
+                LocalDate.of(2024, 3, 1) to LocalDate.of(2024, 3, 31),   // hele mars
+                LocalDate.of(2024, 4, 1) to LocalDate.of(2024, 4, 30)    // hele april
+            )
+        ),
+    ).map { argumentSet(it.description, it) }
+
+    private fun belopTestData() = listOf(
+        // Test case for avrunding av delvise måneder
+        BelopTestCase(
+            description = "Avrunding for delvis måned med 31 dager",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("31000"),
+                    startDato = LocalDate.of(2024, 1, 15),
+                    sluttDato = LocalDate.of(2024, 1, 31),
+                    beskrivelse = "Test delvis januar"
+                )
+            ),
+            intervall = FakturaserieIntervall.MANEDLIG,
+            expectedBelopPerFaktura = listOf(
+                ExpectedBelop(
+                    LocalDate.of(2024, 1, 15),
+                    LocalDate.of(2024, 1, 31),
+                    BigDecimal("17050.00")  // 31000 * (17/31) ≈ 17050.00 der 17/31 ≈ 0.55
+                )
+            )
+        ),
+
+        BelopTestCase(
+            description = "Avrunding for delvis måned med overgang mellom måneder",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("30000"),
+                    startDato = LocalDate.of(2024, 1, 20),
+                    sluttDato = LocalDate.of(2024, 1, 31),
+                    beskrivelse = "Test periode over månedsskifte"
+                )
+            ),
+            intervall = FakturaserieIntervall.MANEDLIG,
+            expectedBelopPerFaktura = listOf(
+                ExpectedBelop(
+                    LocalDate.of(2024, 1, 20),
+                    LocalDate.of(2024, 1, 31),
+                    BigDecimal("11700.00")  // 30000 * (12/31) ≈ 11700.00 der 12/31 ≈ 0.39
+                )
+            )
+        ),
+
+        BelopTestCase(
+            description = "Avrunding for delvis måned i skuddår (februar)",
+            dagensDato = LocalDate.of(2024, 1, 1),
+            perioder = listOf(
+                FakturaseriePeriode(
+                    enhetsprisPerManed = BigDecimal("29000"),
+                    startDato = LocalDate.of(2024, 2, 15),
+                    sluttDato = LocalDate.of(2024, 2, 29),
+                    beskrivelse = "Test delvis februar i skuddår"
+                )
+            ),
+            intervall = FakturaserieIntervall.MANEDLIG,
+            expectedBelopPerFaktura = listOf(
+                ExpectedBelop(
+                    LocalDate.of(2024, 2, 15),
+                    LocalDate.of(2024, 2, 29),
+                    BigDecimal("15080.00")  // 29000 * (15/29) ≈ 15080.00 der 15/29 ≈ 0.51
+                )
+            )
+        )
+    ).map { argumentSet(it.description, it) }
+}

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaGeneratorTest.kt
@@ -30,8 +30,11 @@ class FakturaGeneratorTest {
     @Test
     fun `Periode har opphold - setter ikke faktura for oppholdet`() {
         val faktura = generator.lagFakturaerFor(
-            LocalDate.parse("2020-01-01"),
-            LocalDate.parse("2022-12-31"),
+            FakturaserieGenerator.genererPeriodisering(
+                LocalDate.parse("2020-01-01"),
+                LocalDate.parse("2022-12-31"),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     BigDecimal(1000),
@@ -45,8 +48,7 @@ class FakturaGeneratorTest {
                     LocalDate.parse("2022-12-31"),
                     "Inntekt: 10000, Dekning: Pensjon og helsedel, Sats 10%"
                 )
-            ),
-            FakturaserieIntervall.KVARTAL
+            )
         )
 
 
@@ -69,8 +71,11 @@ class FakturaGeneratorTest {
     @Test
     fun `PeriodeStart på faktura tilbake i tid - DatoBestilt settes til dagens dato`() {
         val faktura = generator.lagFakturaerFor(
-            LocalDate.now().minusDays(1),
-            LocalDate.now().plusMonths(3),
+            FakturaserieGenerator.genererPeriodisering(
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusMonths(3),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     enhetsprisPerManed = BigDecimal(25470),
@@ -78,8 +83,7 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.now().plusMonths(3),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 )
-            ),
-            FakturaserieIntervall.KVARTAL
+            )
         )
         faktura.first().datoBestilt.shouldBe(LocalDate.now())
     }
@@ -91,8 +95,11 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns begynnelseAvDesember
 
         val faktura = generator.lagFakturaerFor(
-            LocalDate.of(2024, 1, 1),
-            LocalDate.of(2024, 5, 20),
+            FakturaserieGenerator.genererPeriodisering(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 5, 20),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     enhetsprisPerManed = BigDecimal(25470),
@@ -106,8 +113,7 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.of(2024, 5, 20),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 )
-            ),
-            FakturaserieIntervall.KVARTAL
+            )
         )
         faktura.sortedBy { it.datoBestilt }.map { it.datoBestilt }
             .shouldContainInOrder(LocalDate.of(2023, 12, 19), LocalDate.of(2024, 3, 19))
@@ -120,8 +126,11 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns etterKvartal1kjøring2024
 
         val faktura = generator.lagFakturaerFor(
-            LocalDate.of(2024, 1, 1),
-            LocalDate.of(2025, 12, 31),
+            FakturaserieGenerator.genererPeriodisering(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2025, 12, 31),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     enhetsprisPerManed = BigDecimal(25470),
@@ -170,11 +179,10 @@ class FakturaGeneratorTest {
                     startDato = LocalDate.of(2025, 10, 1),
                     sluttDato = LocalDate.of(2025, 12, 31),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
-                ),
-
-                ),
-            FakturaserieIntervall.KVARTAL
+                )
+            )
         )
+
         faktura.sortedBy { it.datoBestilt }.map { it.datoBestilt }
             .shouldContainInOrder(
                 LocalDate.of(2024, 3, 22),
@@ -195,8 +203,11 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns begynnelseAvDesember
 
         val faktura = generator.lagFakturaerFor(
-            begynnelseAvDesember.plusDays(4),
-            begynnelseAvDesember.plusDays(20),
+            FakturaserieGenerator.genererPeriodisering(
+                begynnelseAvDesember.plusDays(4),
+                begynnelseAvDesember.plusDays(20),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     enhetsprisPerManed = BigDecimal(25470),
@@ -204,8 +215,7 @@ class FakturaGeneratorTest {
                     sluttDato = begynnelseAvDesember.plusDays(20),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            ),
-            FakturaserieIntervall.KVARTAL
+            )
         )
 
         faktura.single().datoBestilt.shouldBe(LocalDate.now())
@@ -218,8 +228,11 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns begynnelseAvDesember
 
         val faktura = generator.lagFakturaerFor(
-            begynnelseAvDesember.plusYears(1),
-            begynnelseAvDesember.plusYears(1).plusDays(1),
+            FakturaserieGenerator.genererPeriodisering(
+                begynnelseAvDesember.plusYears(1),
+                begynnelseAvDesember.plusYears(1).plusDays(1),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     enhetsprisPerManed = BigDecimal(25470),
@@ -227,8 +240,7 @@ class FakturaGeneratorTest {
                     sluttDato = begynnelseAvDesember.plusYears(1).plusDays(1),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            ),
-            FakturaserieIntervall.KVARTAL
+            )
         )
 
         faktura.single().datoBestilt.shouldBe(LocalDate.of(2024, 9, 19))
@@ -241,8 +253,11 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns etter19SisteMånedIKvartal
 
         val faktura = generator.lagFakturaerFor(
-            LocalDate.of(2024, 2, 1),
-            LocalDate.of(2024, 3, 31),
+            FakturaserieGenerator.genererPeriodisering(
+                LocalDate.of(2024, 2, 1),
+                LocalDate.of(2024, 3, 31),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     enhetsprisPerManed = BigDecimal(25470),
@@ -250,8 +265,7 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.of(2024, 3, 31),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            ),
-            FakturaserieIntervall.KVARTAL
+            )
         )
 
         faktura.single().datoBestilt.shouldBe(etter19SisteMånedIKvartal)
@@ -264,8 +278,11 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns etter19SisteMånedIKvartal
 
         val faktura = generator.lagFakturaerFor(
-            LocalDate.of(2024, 1, 1),
-            LocalDate.of(2027, 3, 31),
+            FakturaserieGenerator.genererPeriodisering(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2027, 3, 31),
+                FakturaserieIntervall.KVARTAL
+            ),
             listOf(
                 FakturaseriePeriode(
                     enhetsprisPerManed = BigDecimal(25470),
@@ -273,8 +290,7 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.of(2027, 3, 31),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            ),
-            FakturaserieIntervall.KVARTAL
+            )
         )
 
         faktura.shouldHaveSize(13)

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaGeneratorTest.kt
@@ -1,6 +1,7 @@
 package no.nav.faktureringskomponenten.service
 
 import io.getunleash.FakeUnleash
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 
-
 class FakturaGeneratorTest {
     private val fakturaLinjeGenerator = FakturaLinjeGenerator()
     private val unleash = FakeUnleash()
@@ -30,7 +30,7 @@ class FakturaGeneratorTest {
     @Test
     fun `Periode har opphold - setter ikke faktura for oppholdet`() {
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 LocalDate.parse("2020-01-01"),
                 LocalDate.parse("2022-12-31"),
                 FakturaserieIntervall.KVARTAL
@@ -48,7 +48,8 @@ class FakturaGeneratorTest {
                     LocalDate.parse("2022-12-31"),
                     "Inntekt: 10000, Dekning: Pensjon og helsedel, Sats 10%"
                 )
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
 
 
@@ -71,7 +72,7 @@ class FakturaGeneratorTest {
     @Test
     fun `PeriodeStart på faktura tilbake i tid - DatoBestilt settes til dagens dato`() {
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 LocalDate.now().minusDays(1),
                 LocalDate.now().plusMonths(3),
                 FakturaserieIntervall.KVARTAL
@@ -83,7 +84,8 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.now().plusMonths(3),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 )
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
         faktura.first().datoBestilt.shouldBe(LocalDate.now())
     }
@@ -95,7 +97,7 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns begynnelseAvDesember
 
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2024, 5, 20),
                 FakturaserieIntervall.KVARTAL
@@ -113,7 +115,8 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.of(2024, 5, 20),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 )
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
         faktura.sortedBy { it.datoBestilt }.map { it.datoBestilt }
             .shouldContainInOrder(LocalDate.of(2023, 12, 19), LocalDate.of(2024, 3, 19))
@@ -126,7 +129,7 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns etterKvartal1kjøring2024
 
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2025, 12, 31),
                 FakturaserieIntervall.KVARTAL
@@ -180,7 +183,8 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.of(2025, 12, 31),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 )
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
 
         faktura.sortedBy { it.datoBestilt }.map { it.datoBestilt }
@@ -203,7 +207,7 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns begynnelseAvDesember
 
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 begynnelseAvDesember.plusDays(4),
                 begynnelseAvDesember.plusDays(20),
                 FakturaserieIntervall.KVARTAL
@@ -215,7 +219,8 @@ class FakturaGeneratorTest {
                     sluttDato = begynnelseAvDesember.plusDays(20),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
 
         faktura.single().datoBestilt.shouldBe(LocalDate.now())
@@ -228,7 +233,7 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns begynnelseAvDesember
 
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 begynnelseAvDesember.plusYears(1),
                 begynnelseAvDesember.plusYears(1).plusDays(1),
                 FakturaserieIntervall.KVARTAL
@@ -240,7 +245,8 @@ class FakturaGeneratorTest {
                     sluttDato = begynnelseAvDesember.plusYears(1).plusDays(1),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
 
         faktura.single().datoBestilt.shouldBe(LocalDate.of(2024, 9, 19))
@@ -253,7 +259,7 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns etter19SisteMånedIKvartal
 
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 LocalDate.of(2024, 2, 1),
                 LocalDate.of(2024, 3, 31),
                 FakturaserieIntervall.KVARTAL
@@ -265,10 +271,344 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.of(2024, 3, 31),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
 
         faktura.single().datoBestilt.shouldBe(etter19SisteMånedIKvartal)
+    }
+
+
+    @Test
+    fun `skal lage en faktura per år for historiske perioder selv om det ikke er siste dag i året`() {
+        val førsteKvartal2023 = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns førsteKvartal2023
+
+        val faktura = generator.lagFakturaerFor(
+            periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+                LocalDate.of(2020, 1, 1),
+                LocalDate.of(2022, 11, 30),  // Merk: Ikke siste dag i året
+                FakturaserieIntervall.KVARTAL
+            ),
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2020, 1, 1),
+                    LocalDate.of(2022, 12, 31),
+                    "Test periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        // Skal få 3 fakturaer (2020, 2021, 2022) selv om siste periode ikke er på slutten av året
+        faktura.shouldHaveSize(3).run {
+            map { it.fakturaLinje.first().periodeFra.year }.shouldContainInOrder(2020, 2021, 2022)
+        }
+    }
+
+    @Test
+    fun `tom periodisering gir tom liste med fakturaer`() {
+        val faktura = generator.lagFakturaerFor(
+            periodisering = emptyList(),
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.parse("2020-01-01"),
+                    LocalDate.parse("2020-12-31"),
+                    "Test periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        faktura.shouldHaveSize(0)
+    }
+
+    @Test
+    fun `tomme fakturaseriePerioder gir tom liste med fakturaer`() {
+        val faktura = generator.lagFakturaerFor(
+            periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+                LocalDate.parse("2020-01-01"),
+                LocalDate.parse("2020-12-31"),
+                FakturaserieIntervall.KVARTAL
+            ),
+            fakturaseriePerioder = emptyList(),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        faktura.shouldHaveSize(0)
+    }
+
+    @Test
+    fun `fremtidige perioder med opphold - setter ikke faktura for oppholdet`() {
+        val dagensDato = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns dagensDato
+
+        val faktura = generator.lagFakturaerFor(
+            FakturaIntervallPeriodisering.genererPeriodisering(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2026, 12, 31),
+                FakturaserieIntervall.KVARTAL
+            ),
+            listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2024, 1, 1),
+                    LocalDate.of(2024, 12, 31),
+                    "Første periode"
+                ),
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2026, 1, 1),
+                    LocalDate.of(2026, 12, 31),
+                    "Andre periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        faktura.flatMap { it.fakturaLinje }
+            .map { it.periodeFra.year }
+            .distinct()
+            .shouldContainInOrder(2024, 2026) // Skal ikke inneholde 2025
+    }
+
+    @Test
+    fun `skal feile når periodisering går utenfor fakturaseriePerioder`() {
+        val dagensDato = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns dagensDato
+
+        shouldThrow<IllegalArgumentException> {
+            generator.lagFakturaerFor(
+                periodisering = listOf(
+                    LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 12, 31),
+                ),
+                fakturaseriePerioder = listOf(
+                    FakturaseriePeriode(
+                        BigDecimal(1000),
+                        LocalDate.of(2024, 1, 1),
+                        LocalDate.of(2024, 6, 30),
+                        "Test periode"
+                    )
+                ),
+                FakturaserieIntervall.KVARTAL
+            )
+        }.message shouldBe  "Periodisering (2024-01-01 til 2024-12-31) må være innenfor faktureringsperiodene (2024-01-01 til 2024-06-30)"
+    }
+
+    @Test
+    fun `alle perioder er i fremtiden - skal lage separate fakturaer per periode`() {
+        val dagensDato = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns dagensDato
+
+        val periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+            LocalDate.of(2024, 1, 1),
+            LocalDate.of(2024, 12, 31),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        val faktura = generator.lagFakturaerFor(
+            periodisering = periodisering,
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2024, 1, 1),
+                    LocalDate.of(2024, 12, 31),
+                    "Test periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        faktura.shouldHaveSize(4) // Ett per kvartal
+    }
+
+    @Test
+    fun `alle perioder er historiske - skal grupperes per år`() {
+        val dagensDato = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns dagensDato
+
+        val periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+            LocalDate.of(2020, 1, 1),
+            LocalDate.of(2022, 12, 31),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        val faktura = generator.lagFakturaerFor(
+            periodisering = periodisering,
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2020, 1, 1),
+                    LocalDate.of(2022, 12, 31),
+                    "Test periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        faktura.shouldHaveSize(3) // En per år (2020, 2021, 2022)
+    }
+
+    @Test
+    fun `overlappende fakturaseriePerioder - skal håndtere overlapp korrekt`() {
+        val dagensDato = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns dagensDato
+
+        val startDato = LocalDate.of(2024, 1, 1)
+        val overlappStartDato = LocalDate.of(2024, 3, 15)
+        val sluttDatoFørstePeriode = LocalDate.of(2024, 3, 31)
+        val sluttDato = LocalDate.of(2024, 6, 30)
+
+        val beløpFørstePeriode = BigDecimal(1000)
+        val beløpAndrePeriode = BigDecimal(2000)
+
+        // Act
+        val fakturaer = generator.lagFakturaerFor(
+            periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.KVARTAL
+            ),
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    beløpFørstePeriode,
+                    startDato,
+                    sluttDatoFørstePeriode,
+                    "Første periode"
+                ),
+                FakturaseriePeriode(
+                    beløpAndrePeriode,
+                    overlappStartDato,
+                    sluttDato,
+                    "Andre periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        val fakturaLinjer = fakturaer.flatMap { it.fakturaLinje }.sortedBy { it.periodeFra }
+
+        with(fakturaLinjer) {
+            size.shouldBe(3)
+            // Første kvartal (1. jan - 31. mars med 1000kr)
+            first().let { linje ->
+                linje.periodeFra.shouldBe(startDato)
+                linje.periodeTil.shouldBe(sluttDatoFørstePeriode)
+                linje.enhetsprisPerManed.shouldBe(beløpFørstePeriode)
+                // 3 måneder med 1000kr per måned
+                linje.belop.toString().shouldBe("3000.00")
+            }
+
+            // Overlappende periode (15. mars - 31. mars)
+            get(1).let { linje ->
+                linje.periodeFra.shouldBe(overlappStartDato)
+                linje.periodeTil.shouldBe(sluttDatoFørstePeriode)
+                linje.enhetsprisPerManed.shouldBe(2000.toBigDecimal())
+                linje.belop.toString().shouldBe("1100.00") // (31/16) * 2000
+            }
+
+            // Andre kvartal (1. april - 30. juni med 2000kr)
+            last().let { linje ->
+                linje.periodeFra.shouldBe(sluttDatoFørstePeriode.plusDays(1))
+                linje.periodeTil.shouldBe(sluttDato)
+                linje.enhetsprisPerManed.shouldBe(beløpAndrePeriode)
+                // 3 måneder med 2000kr per måned
+                linje.belop.toString().shouldBe("6000.00")
+            }
+        }
+    }
+
+    @Test
+    fun `periodisering som starter midt i en måned`() {
+        val dagensDato = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns dagensDato
+
+        val faktura = generator.lagFakturaerFor(
+            periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+                LocalDate.of(2024, 1, 15), // Merk: Starter midt i måneden
+                LocalDate.of(2024, 6, 30),
+                FakturaserieIntervall.KVARTAL
+            ),
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2024, 1, 1),
+                    LocalDate.of(2024, 6, 30),
+                    "Test periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        // Verifiser at første fakturalinjes startdato er 15. januar
+        faktura.first().fakturaLinje.first().periodeFra.shouldBe(LocalDate.of(2024, 1, 15))
+    }
+
+    @Test
+    fun `fakturaseriePeriode som delvis overlapper med periodisering`() {
+        val dagensDato = LocalDate.of(2023, 12, 1)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns dagensDato
+
+        val faktura = generator.lagFakturaerFor(
+            periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 3, 31),
+                FakturaserieIntervall.KVARTAL
+            ),
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2023, 12, 15), // Starter før periodisering
+                    LocalDate.of(2024, 4, 15),  // Slutter etter periodisering
+                    "Test periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        faktura.flatMap { it.fakturaLinje }.run {
+            first().periodeFra.shouldBe(LocalDate.of(2024, 1, 1)) // Skal starte med periodiseringen
+            last().periodeTil.shouldBe(LocalDate.of(2024, 3, 31)) // Skal slutte med periodiseringen
+        }
+    }
+
+    @Test
+    fun `dagensDato er nøyaktig på grensen mellom historisk og fremtidig, produserer to faktura`() {
+        val grenseDato = LocalDate.of(2024, 3, 31)
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns grenseDato
+
+        val faktura = generator.lagFakturaerFor(
+            periodisering = FakturaIntervallPeriodisering.genererPeriodisering(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 6, 30),
+                FakturaserieIntervall.KVARTAL
+            ),
+            fakturaseriePerioder = listOf(
+                FakturaseriePeriode(
+                    BigDecimal(1000),
+                    LocalDate.of(2024, 1, 1),
+                    LocalDate.of(2024, 6, 30),
+                    "Test periode"
+                )
+            ),
+            FakturaserieIntervall.KVARTAL
+        )
+
+        // Første kvartal skal være historisk, andre kvartal fremtidig
+        faktura.shouldHaveSize(2)
+        faktura.first().fakturaLinje.first().periodeFra.shouldBe(LocalDate.of(2024, 1, 1))
+        faktura.last().fakturaLinje.first().periodeFra.shouldBe(LocalDate.of(2024, 4, 1))
     }
 
     @Test
@@ -278,7 +618,7 @@ class FakturaGeneratorTest {
         every { LocalDate.now() } returns etter19SisteMånedIKvartal
 
         val faktura = generator.lagFakturaerFor(
-            FakturaserieGenerator.genererPeriodisering(
+            FakturaIntervallPeriodisering.genererPeriodisering(
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2027, 3, 31),
                 FakturaserieIntervall.KVARTAL
@@ -290,7 +630,8 @@ class FakturaGeneratorTest {
                     sluttDato = LocalDate.of(2027, 3, 31),
                     beskrivelse = "Inntekt: 90000, Dekning: HELSE_OG_PENSJONSDEL, Sats: 28.3 %"
                 ),
-            )
+            ),
+            FakturaserieIntervall.KVARTAL
         )
 
         faktura.shouldHaveSize(13)

--- a/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaIntervallPeriodiseringTest.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/service/FakturaIntervallPeriodiseringTest.kt
@@ -1,0 +1,295 @@
+package no.nav.faktureringskomponenten.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.faktureringskomponenten.domain.models.FakturaserieIntervall
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@DisplayName("FakturaIntervallPeriodiseringTest")
+class FakturaIntervallPeriodiseringTest {
+
+    @Nested
+    @DisplayName("genererPeriodisering for intervall MÅNEDLIG")
+    inner class MånedligIntervallTest {
+        @Test
+        fun `skal generere korrekte perioder for én måned`() {
+            val startDato = LocalDate.of(2024, 1, 1)
+            val sluttDato = LocalDate.of(2024, 1, 31)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 1
+            perioder.first() shouldBe (startDato to sluttDato)
+        }
+
+        @Test
+        fun `skal generere korrekte perioder for tre måneder`() {
+            val startDato = LocalDate.of(2024, 1, 1)
+            val sluttDato = LocalDate.of(2024, 3, 31)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 3
+            perioder[0] shouldBe (LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 1, 31))
+            perioder[1] shouldBe (LocalDate.of(2024, 2, 1) to LocalDate.of(2024, 2, 29))
+            perioder[2] shouldBe (LocalDate.of(2024, 3, 1) to LocalDate.of(2024, 3, 31))
+        }
+
+        @Test
+        fun `skal håndtere skuddår korrekt`() {
+            val startDato = LocalDate.of(2024, 2, 1)
+            val sluttDato = LocalDate.of(2024, 2, 29)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 1
+            perioder.first() shouldBe (startDato to sluttDato)
+        }
+
+        @Test
+        fun `skal generere korrekte perioder over årsskifte`() {
+            val startDato = LocalDate.of(2024, 12, 1)
+            val sluttDato = LocalDate.of(2025, 2, 28)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 3
+            perioder[0] shouldBe (LocalDate.of(2024, 12, 1) to LocalDate.of(2024, 12, 31))
+            perioder[1] shouldBe (LocalDate.of(2025, 1, 1) to LocalDate.of(2025, 1, 31))
+            perioder[2] shouldBe (LocalDate.of(2025, 2, 1) to LocalDate.of(2025, 2, 28))
+        }
+
+        @Test
+        fun `skal generere korrekte perioder for et helt år med delperioder i start og slutt`() {
+            val startDato = LocalDate.of(2024, 3, 15)
+            val sluttDato = LocalDate.of(2025, 2, 15)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 12
+            perioder[0] shouldBe (LocalDate.of(2024, 3, 15) to LocalDate.of(2024, 3, 31))
+            perioder[1] shouldBe (LocalDate.of(2024, 4, 1) to LocalDate.of(2024, 4, 30))
+            perioder[2] shouldBe (LocalDate.of(2024, 5, 1) to LocalDate.of(2024, 5, 31))
+            perioder[3] shouldBe (LocalDate.of(2024, 6, 1) to LocalDate.of(2024, 6, 30))
+            perioder[4] shouldBe (LocalDate.of(2024, 7, 1) to LocalDate.of(2024, 7, 31))
+            perioder[5] shouldBe (LocalDate.of(2024, 8, 1) to LocalDate.of(2024, 8, 31))
+            perioder[6] shouldBe (LocalDate.of(2024, 9, 1) to LocalDate.of(2024, 9, 30))
+            perioder[7] shouldBe (LocalDate.of(2024, 10, 1) to LocalDate.of(2024, 10, 31))
+            perioder[8] shouldBe (LocalDate.of(2024, 11, 1) to LocalDate.of(2024, 11, 30))
+            perioder[9] shouldBe (LocalDate.of(2024, 12, 1) to LocalDate.of(2024, 12, 31))
+            perioder[10] shouldBe (LocalDate.of(2025, 1, 1) to LocalDate.of(2025, 1, 31))
+            perioder[11] shouldBe (LocalDate.of(2025, 2, 1) to LocalDate.of(2025, 2, 15))
+        }
+
+        @Test
+        fun `skal håndtere skuddår og ikke-skuddår over flere år`() {
+            val startDato = LocalDate.of(2024, 2, 1)  // skuddår
+            val sluttDato = LocalDate.of(2025, 2, 28) // ikke skuddår
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 13
+            perioder[0] shouldBe (LocalDate.of(2024, 2, 1) to LocalDate.of(2024, 2, 29))  // skuddår februar
+            perioder[12] shouldBe (LocalDate.of(2025, 2, 1) to LocalDate.of(2025, 2, 28)) // normal februar
+        }
+    }
+
+    @Nested
+    @DisplayName("genererPeriodisering for intervall KVARTAL")
+    inner class KvartalvisIntervallTest {
+
+        @Test
+        fun `skal generere korrekte perioder for ett kvartal`() {
+            val startDato = LocalDate.of(2024, 1, 1)
+            val sluttDato = LocalDate.of(2024, 3, 31)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.KVARTAL
+            )
+
+            perioder shouldHaveSize 1
+            perioder.first() shouldBe (startDato to sluttDato)
+        }
+
+        @Test
+        fun `skal generere korrekte perioder for helt år`() {
+            val startDato = LocalDate.of(2024, 1, 1)
+            val sluttDato = LocalDate.of(2024, 12, 31)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.KVARTAL
+            )
+
+            perioder shouldHaveSize 4
+            perioder[0] shouldBe (LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 3, 31))
+            perioder[1] shouldBe (LocalDate.of(2024, 4, 1) to LocalDate.of(2024, 6, 30))
+            perioder[2] shouldBe (LocalDate.of(2024, 7, 1) to LocalDate.of(2024, 9, 30))
+            perioder[3] shouldBe (LocalDate.of(2024, 10, 1) to LocalDate.of(2024, 12, 31))
+        }
+
+        @Test
+        fun `skal håndtere delperioder av kvartal`() {
+            val startDato = LocalDate.of(2024, 2, 15)
+            val sluttDato = LocalDate.of(2024, 5, 15)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.KVARTAL
+            )
+
+            perioder shouldHaveSize 2
+            perioder[0] shouldBe (LocalDate.of(2024, 2, 15) to LocalDate.of(2024, 3, 31))
+            perioder[1] shouldBe (LocalDate.of(2024, 4, 1) to LocalDate.of(2024, 5, 15))
+        }
+
+        @Test
+        fun `skal generere korrekte perioder over to år`() {
+            val startDato = LocalDate.of(2024, 10, 1)
+            val sluttDato = LocalDate.of(2025, 3, 31)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.KVARTAL
+            )
+
+            perioder shouldHaveSize 2
+            perioder[0] shouldBe (LocalDate.of(2024, 10, 1) to LocalDate.of(2024, 12, 31))
+            perioder[1] shouldBe (LocalDate.of(2025, 1, 1) to LocalDate.of(2025, 3, 31))
+        }
+
+        @Test
+        fun `skal generere korrekte perioder for tre år`() {
+            val startDato = LocalDate.of(2024, 1, 1)
+            val sluttDato = LocalDate.of(2026, 12, 31)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.KVARTAL
+            )
+
+            perioder shouldHaveSize 12
+            // 2024
+            perioder[0] shouldBe (LocalDate.of(2024, 1, 1) to LocalDate.of(2024, 3, 31))
+            perioder[1] shouldBe (LocalDate.of(2024, 4, 1) to LocalDate.of(2024, 6, 30))
+            perioder[2] shouldBe (LocalDate.of(2024, 7, 1) to LocalDate.of(2024, 9, 30))
+            perioder[3] shouldBe (LocalDate.of(2024, 10, 1) to LocalDate.of(2024, 12, 31))
+            // 2025
+            perioder[4] shouldBe (LocalDate.of(2025, 1, 1) to LocalDate.of(2025, 3, 31))
+            perioder[5] shouldBe (LocalDate.of(2025, 4, 1) to LocalDate.of(2025, 6, 30))
+            perioder[6] shouldBe (LocalDate.of(2025, 7, 1) to LocalDate.of(2025, 9, 30))
+            perioder[7] shouldBe (LocalDate.of(2025, 10, 1) to LocalDate.of(2025, 12, 31))
+            // 2026
+            perioder[8] shouldBe (LocalDate.of(2026, 1, 1) to LocalDate.of(2026, 3, 31))
+            perioder[9] shouldBe (LocalDate.of(2026, 4, 1) to LocalDate.of(2026, 6, 30))
+            perioder[10] shouldBe (LocalDate.of(2026, 7, 1) to LocalDate.of(2026, 9, 30))
+            perioder[11] shouldBe (LocalDate.of(2026, 10, 1) to LocalDate.of(2026, 12, 31))
+        }
+
+        @Test
+        fun `skal håndtere delperiode i start og slutt over flere år`() {
+            val startDato = LocalDate.of(2024, 11, 15)
+            val sluttDato = LocalDate.of(2026, 2, 15)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.KVARTAL
+            )
+
+            perioder shouldHaveSize 6
+            perioder[0] shouldBe (LocalDate.of(2024, 11, 15) to LocalDate.of(2024, 12, 31))
+            perioder[1] shouldBe (LocalDate.of(2025, 1, 1) to LocalDate.of(2025, 3, 31))
+            perioder[2] shouldBe (LocalDate.of(2025, 4, 1) to LocalDate.of(2025, 6, 30))
+            perioder[3] shouldBe (LocalDate.of(2025, 7, 1) to LocalDate.of(2025, 9, 30))
+            perioder[4] shouldBe (LocalDate.of(2025, 10, 1) to LocalDate.of(2025, 12, 31))
+            perioder[5] shouldBe (LocalDate.of(2026, 1, 1) to LocalDate.of(2026, 2, 15))
+        }
+    }
+
+    @Nested
+    @DisplayName("genererPeriodisering for intervall SINGEL")
+    inner class SingelIntervallTest {
+
+        @Test
+        fun `skal kaste IllegalArgumentException`() {
+            val startDato = LocalDate.of(2024, 1, 1)
+            val sluttDato = LocalDate.of(2024, 12, 31)
+
+            shouldThrow<IllegalArgumentException> {
+                FakturaIntervallPeriodisering.genererPeriodisering(
+                    startDato,
+                    sluttDato,
+                    FakturaserieIntervall.SINGEL
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("edge cases")
+    inner class EdgeCasesTest {
+
+        @Test
+        fun `skal håndtere når start- og sluttdato er samme dag`() {
+            val dato = LocalDate.of(2024, 1, 1)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                dato,
+                dato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 1
+            perioder.first() shouldBe (dato to dato)
+        }
+
+        @Test
+        fun `skal returnere tom liste når startdato er etter sluttdato`() {
+            val startDato = LocalDate.of(2024, 2, 1)
+            val sluttDato = LocalDate.of(2024, 1, 1)
+
+            val perioder = FakturaIntervallPeriodisering.genererPeriodisering(
+                startDato,
+                sluttDato,
+                FakturaserieIntervall.MANEDLIG
+            )
+
+            perioder shouldHaveSize 0
+        }
+    }
+}


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6980

Jeg tenker at logikk for periodisering hører sammen med fakturaserier, samtidig trenger `FakturaGenerator` å vite om dagens dato og periodisering, for å kunne vite om fakturalinjer havner i en ny faktura.
Derfor har jeg flyttet logikk om periodisering i `FakturaserieGenerator`