### PR TITLE
NOJIRA: Negate enhetsprisPerMåned på admin-endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
@@ -43,6 +43,7 @@ class AdminService(
             datoBestilt = LocalDate.now(),
             fakturaLinje = faktura.fakturaLinje.map {
                 FakturaLinje(
+                    enhetsprisPerManed = it.enhetsprisPerManed.negate(),
                     periodeFra = it.periodeFra,
                     periodeTil = it.periodeTil,
                     belop = it.belop.negate(),


### PR DESCRIPTION
Det feiler i OEBS når defaultverdien sendes (0)