### PR TITLE
Vakt: Midlertidig disable deploy til q1

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -79,14 +79,14 @@ jobs:
           IMAGE: ${{ needs.build.outputs.image }}
           VARS: nais/vars-q2.json
           TELEMETRY: ${{ needs.build.outputs.telemetry }}
-      - name: Deploy til dev (Q1)
-        uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: dev-gcp
-          RESOURCE: nais/nais.yml
-          IMAGE: ${{ needs.build.outputs.image }}
-          VARS: nais/vars-q1.json
-          TELEMETRY: ${{ needs.build.outputs.telemetry }}
+      #- name: Deploy til dev (Q1)
+      #  uses: nais/deploy/actions/deploy@v2
+      #  env:
+      #    CLUSTER: dev-gcp
+      #    RESOURCE: nais/nais.yml
+      #    IMAGE: ${{ needs.build.outputs.image }}
+      #    VARS: nais/vars-q1.json
+      #    TELEMETRY: ${{ needs.build.outputs.telemetry }}
       - name: Get commit message
         run: echo "COMMIT_MSG=$(git log --format=%s -n 1)" >> $GITHUB_ENV
       - name: Slack Notification


### PR DESCRIPTION
Deploy til q1 feiler akkurat nå, uten at jeg kan fort forklare hvorfor. Virker å være et problem med miljø i q1. Disabler midleritidig for å fikse vaktsaken.