### PR TITLE
VAKT Legg til admin-endepunkt for endring av fødselsnummer på fakturaserie

### DIFF
--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/AdminController.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/AdminController.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import jakarta.validation.Valid
 import mu.KotlinLogging
 import no.nav.faktureringskomponenten.controller.FakturaserieController.KanselleringRequestDto
 import no.nav.faktureringskomponenten.controller.dto.FakturaAdminDto
@@ -11,6 +12,7 @@ import no.nav.faktureringskomponenten.controller.dto.FakturaserieResponseDto
 import no.nav.faktureringskomponenten.controller.dto.NyFakturaserieResponseDto
 import no.nav.faktureringskomponenten.controller.dto.toFakturaAdminDto
 import no.nav.faktureringskomponenten.controller.mapper.tilFakturaserieResponseDto
+import no.nav.faktureringskomponenten.controller.validators.ErFodselsnummer
 import no.nav.faktureringskomponenten.controller.validators.OrganisasjonsnummerValidator
 import no.nav.faktureringskomponenten.domain.models.AvstemmingCsvRad
 import no.nav.faktureringskomponenten.domain.models.FakturaMottakFeil
@@ -275,6 +277,17 @@ class AdminController(
         return faktureringService.hentFakturaserie(referanse).tilFakturaserieResponseDto(inkluderFodselsnummer = false)
     }
 
+    @Operation(summary = "Endrer fødselsnummer på en fakturaserie")
+    @PutMapping("/fakturaserie/{referanse}/fnr")
+    fun endreFødselsnummer(
+        @PathVariable referanse: String,
+        @Valid @RequestBody request: EndreFødselsnummerRequest
+    ): ResponseEntity<String> {
+        log.info("Mottatt forespørsel om endring av fødselsnummer på fakturaserie: $referanse")
+        adminService.endreFødselsnummer(referanse, request.nyttFnr)
+        return ResponseEntity.ok("Fødselsnummer endret på fakturaserie $referanse")
+    }
+
     @Operation(summary = "Henter faktura med ekstern faktura status og fakturaserie referanse")
     @GetMapping("/faktura/status")
     fun hentFakturaMedStatus(
@@ -327,6 +340,11 @@ class AdminController(
 data class ManglendeInnbetalingSimuleringDto(
     val betaltBelop: BigDecimal,
     val fakturaNummer: String
+)
+
+data class EndreFødselsnummerRequest(
+    @field:ErFodselsnummer
+    val nyttFnr: String
 )
 
 

--- a/src/main/kotlin/no/nav/faktureringskomponenten/controller/validators/ErFodselsnummer.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/controller/validators/ErFodselsnummer.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 
 @MustBeDocumented
 @Constraint(validatedBy = [FodselsnummerValidator::class])
-@Target(AnnotationTarget.FIELD)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class ErFodselsnummer(
     val message: String = "Fødselsnummeret er ikke gyldig",

--- a/src/main/kotlin/no/nav/faktureringskomponenten/domain/models/Fakturaserie.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/domain/models/Fakturaserie.kt
@@ -19,7 +19,7 @@ class Fakturaserie(
     val fakturaGjelderInnbetalingstype: Innbetalingstype = Innbetalingstype.TRYGDEAVGIFT,
 
     @Column(name = "fodselsnummer", nullable = false)
-    val fodselsnummer: String = "",
+    var fodselsnummer: String = "",
 
     @Embedded
     var fullmektig: Fullmektig? = null,

--- a/src/main/kotlin/no/nav/faktureringskomponenten/exceptions/config/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/exceptions/config/ExceptionHandler.kt
@@ -25,6 +25,12 @@ class ExceptionHandler: ResponseEntityExceptionHandler() {
     @ExceptionHandler(ConstraintViolationException::class)
     fun handleConstraintViolationException(ex: ConstraintViolationException): ProblemDetail {
         val melding = ex.constraintViolations.joinToString(", ") { it.message }
-        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, melding)
+        val problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, melding)
+        problemDetail.apply {
+            title = "ConstraintViolationException"
+            detail = melding
+        }
+        problemDetail.setProperty("message", melding)
+        return problemDetail
     }
 }

--- a/src/main/kotlin/no/nav/faktureringskomponenten/exceptions/config/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/exceptions/config/ExceptionHandler.kt
@@ -1,5 +1,6 @@
 package no.nav.faktureringskomponenten.exceptions.config
 
+import jakarta.validation.ConstraintViolationException
 import no.nav.faktureringskomponenten.exceptions.RessursIkkeFunnetException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
@@ -19,5 +20,11 @@ class ExceptionHandler: ResponseEntityExceptionHandler() {
         }
         problemDetail.setProperty("message", ressursIkkeFunnetException.message)
         return problemDetail
+    }
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolationException(ex: ConstraintViolationException): ProblemDetail {
+        val melding = ex.constraintViolations.joinToString(", ") { it.message }
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, melding)
     }
 }

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
@@ -7,10 +7,13 @@ import no.nav.faktureringskomponenten.exceptions.RessursIkkeFunnetException
 import no.nav.faktureringskomponenten.service.avregning.AvregningsfakturaGenerator
 import no.nav.faktureringskomponenten.service.integration.kafka.FakturaBestiltProducer
 import no.nav.faktureringskomponenten.service.mappers.FakturaBestiltDtoMapper
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import ulid.ULID
 import java.math.BigDecimal
 import java.time.LocalDate
+
+private val log = KotlinLogging.logger { }
 
 @Service
 class AdminService(
@@ -18,6 +21,25 @@ class AdminService(
     private val fakturaserieRepository: FakturaserieRepository,
     private val fakturaBestiltProducer: FakturaBestiltProducer,
 ) {
+
+    @Transactional
+    fun endreFødselsnummer(fakturaserieReferanse: String, nyttFødselsnummer: String) {
+        val fakturaserie = fakturaserieRepository.findByReferanse(fakturaserieReferanse)
+            ?: throw RessursIkkeFunnetException(
+                field = "referanse",
+                message = "Fant ikke fakturaserie med referanse: $fakturaserieReferanse"
+            )
+
+        if (fakturaserie.fodselsnummer == nyttFødselsnummer) {
+            log.info("Fødselsnummer er allerede satt til ønsket verdi på fakturaserie $fakturaserieReferanse")
+            return
+        }
+
+        fakturaserie.fodselsnummer = nyttFødselsnummer
+        fakturaserieRepository.save(fakturaserie)
+
+        log.info("Endret fødselsnummer på fakturaserie $fakturaserieReferanse")
+    }
     @Transactional
     fun krediterFaktura(fakturaReferanse: String): Fakturaserie {
         val faktura = fakturaService.hentFaktura(fakturaReferanse) ?: throw RessursIkkeFunnetException(

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
@@ -1,6 +1,6 @@
 package no.nav.faktureringskomponenten.service
 
-import jakarta.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 import no.nav.faktureringskomponenten.domain.models.*
 import no.nav.faktureringskomponenten.domain.repositories.FakturaserieRepository
 import no.nav.faktureringskomponenten.exceptions.RessursIkkeFunnetException

--- a/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/faktureringskomponenten/service/AdminService.kt
@@ -1,14 +1,17 @@
 package no.nav.faktureringskomponenten.service
 
-import org.springframework.transaction.annotation.Transactional
-import no.nav.faktureringskomponenten.domain.models.*
+import mu.KotlinLogging
+import no.nav.faktureringskomponenten.domain.models.Faktura
+import no.nav.faktureringskomponenten.domain.models.FakturaLinje
+import no.nav.faktureringskomponenten.domain.models.FakturaStatus
+import no.nav.faktureringskomponenten.domain.models.Fakturaserie
 import no.nav.faktureringskomponenten.domain.repositories.FakturaserieRepository
 import no.nav.faktureringskomponenten.exceptions.RessursIkkeFunnetException
 import no.nav.faktureringskomponenten.service.avregning.AvregningsfakturaGenerator
 import no.nav.faktureringskomponenten.service.integration.kafka.FakturaBestiltProducer
 import no.nav.faktureringskomponenten.service.mappers.FakturaBestiltDtoMapper
-import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import ulid.ULID
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -40,6 +43,7 @@ class AdminService(
 
         log.info("Endret fødselsnummer på fakturaserie $fakturaserieReferanse")
     }
+
     @Transactional
     fun krediterFaktura(fakturaReferanse: String): Fakturaserie {
         val faktura = fakturaService.hentFaktura(fakturaReferanse) ?: throw RessursIkkeFunnetException(

--- a/src/test/kotlin/no/nav/faktureringskomponenten/controller/AdminControllerIT.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/controller/AdminControllerIT.kt
@@ -167,12 +167,62 @@ class AdminControllerIT(
         oppdatertFakturaserie.fullmektig?.organisasjonsnummer shouldBe opprinneligMottaker
     }
 
+    @Test
+    fun `endreFødselsnummer oppdaterer fødselsnummer på fakturaserie`() {
+        val fakturaserieDto = lagFakturaserieDto(fodselsnummer = "12345678911")
+
+        val fakturaserieReferanse = postLagNyFakturaserieRequest(fakturaserieDto)
+            .expectStatus().isOk
+            .expectBody<NyFakturaserieResponseDto>()
+            .returnResult().responseBody!!.fakturaserieReferanse
+
+        val nyttFødselsnummer = "99887766554"
+        putEndreFødselsnummerRequest(fakturaserieReferanse, nyttFødselsnummer)
+            .expectStatus().isOk
+
+        val oppdatertFakturaserie = fakturaserieRepositoryForTesting.findByReferanseEagerly(fakturaserieReferanse)!!
+        oppdatertFakturaserie.fodselsnummer shouldBe nyttFødselsnummer
+    }
+
+    @Test
+    fun `endreFødselsnummer feiler med ugyldig fødselsnummer`() {
+        val fakturaserieDto = lagFakturaserieDto()
+
+        val fakturaserieReferanse = postLagNyFakturaserieRequest(fakturaserieDto)
+            .expectStatus().isOk
+            .expectBody<NyFakturaserieResponseDto>()
+            .returnResult().responseBody!!.fakturaserieReferanse
+
+        putEndreFødselsnummerRequest(fakturaserieReferanse, "123")
+            .expectStatus().isBadRequest
+    }
+
+    @Test
+    fun `endreFødselsnummer feiler når fakturaserie ikke finnes`() {
+        putEndreFødselsnummerRequest("finnes-ikke", "99887766554")
+            .expectStatus().isNotFound
+    }
+
     private fun hentAvstemmingCsvRequest(
         periodeFra: LocalDate = LocalDate.of(2020, 1, 1),
         periodeTil: LocalDate = LocalDate.of(2030, 12, 31)
     ): WebTestClient.ResponseSpec =
         webClient.get()
             .uri("/admin/avstemming/csv?periodeFra=$periodeFra&periodeTil=$periodeTil")
+            .headers {
+                it.set(HttpHeaders.AUTHORIZATION, "Bearer " + token())
+            }
+            .exchange()
+
+    private fun putEndreFødselsnummerRequest(
+        fakturaserieReferanse: String,
+        nyttFødselsnummer: String
+    ): WebTestClient.ResponseSpec =
+        webClient.put()
+            .uri("/admin/fakturaserie/$fakturaserieReferanse/fnr")
+            .header("Nav-User-Id", NAV_IDENT)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(mapOf("nyttFnr" to nyttFødselsnummer))
             .headers {
                 it.set(HttpHeaders.AUTHORIZATION, "Bearer " + token())
             }

--- a/src/test/kotlin/no/nav/faktureringskomponenten/controller/AdminControllerIT.kt
+++ b/src/test/kotlin/no/nav/faktureringskomponenten/controller/AdminControllerIT.kt
@@ -1,6 +1,7 @@
 package no.nav.faktureringskomponenten.controller
 
 import com.nimbusds.jose.JOSEObjectType
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import no.nav.faktureringskomponenten.controller.dto.*
@@ -182,6 +183,8 @@ class AdminControllerIT(
 
         val oppdatertFakturaserie = fakturaserieRepositoryForTesting.findByReferanseEagerly(fakturaserieReferanse)!!
         oppdatertFakturaserie.fodselsnummer shouldBe nyttFødselsnummer
+        oppdatertFakturaserie.endretAv shouldBe NAV_IDENT
+        oppdatertFakturaserie.endretTidspunkt.shouldNotBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Sammendrag

- Nytt admin-endepunkt `PUT /admin/fakturaserie/{referanse}/fnr` for å endre fødselsnummer på en fakturaserie
- Brukere kan få nytt dnr eller fnr i løpet av livet, og dette endepunktet kan oppdatere fakturaserien uten å måtte kansellere og opprette på nytt
- Endringen spores via JPA-auditing (`endretAv`, `endretTidspunkt`)
